### PR TITLE
docs(wiki): fix internal links to use .md for GitHub viewer

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -78,9 +78,9 @@ app.listen(3000)
 ## Documentation
 
 ### Start Here
-- [AI Agent Quick Reference](AI-Agent-Quick-Reference) — copy/paste setup for agents and automation
-- [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App) — one-command local demo with Dependencies graph
-- [Implementation Status](Implementation-Status) — current state, demos, and observability
+- [AI Agent Quick Reference](AI-Agent-Quick-Reference.md) — copy/paste setup for agents and automation
+- [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App.md) — one-command local demo with Dependencies graph
+- [Implementation Status](Implementation-Status.md) — current state, demos, and observability
 
 ### Getting Started
 - **[Installation](Installation)** - Install and setup the RDCP SDK
@@ -93,32 +93,32 @@ app.listen(3000)
 - **[Next.js Integration](Basic-Usage#next-js)** - Next.js App Router implementation
 
 ### OpenTelemetry Integration
-- [Trace Propagation Demo](examples/Trace-Propagation-Demo) — upstream → rdcp-demo-app with cross-service tracing
-- **[OpenTelemetry Overview](examples/opentelemetry/Overview)** - Enterprise-grade trace correlation with RDCP debug logs
-- **[Framework Examples](examples/opentelemetry/Framework-Examples)** - Production-ready integrations for Express, Next.js, Fastify, Koa
-- **[Migration Guides](examples/opentelemetry/Migration-Guides)** - Step-by-step migration from existing logging to RDCP + OpenTelemetry
-- **[Backend Configurations](examples/opentelemetry/Backend-Configurations)** - Working examples for Jaeger, DataDog, New Relic, and more
-- **[DataDog Quickstart](examples/opentelemetry/DataDog-Quickstart)** - 10-minute path to Datadog APM + RDCP correlation
-- **[New Relic Quickstart](examples/opentelemetry/NewRelic-Quickstart)** - 10-minute path to New Relic + RDCP correlation
-- **[Performance Analysis](examples/opentelemetry/Performance-Analysis)** - Benchmarks, overhead measurement, and production tuning
+- [Trace Propagation Demo](examples/Trace-Propagation-Demo.md) — upstream → rdcp-demo-app with cross-service tracing
+- **[OpenTelemetry Overview](examples/opentelemetry/Overview.md)** - Enterprise-grade trace correlation with RDCP debug logs
+- **[Framework Examples](examples/opentelemetry/Framework-Examples.md)** - Production-ready integrations for Express, Next.js, Fastify, Koa
+- **[Migration Guides](examples/opentelemetry/Migration-Guides.md)** - Step-by-step migration from existing logging to RDCP + OpenTelemetry
+- **[Backend Configurations](examples/opentelemetry/Backend-Configurations.md)** - Working examples for Jaeger, DataDog, New Relic, and more
+- **[DataDog Quickstart](examples/opentelemetry/DataDog-Quickstart.md)** - 10-minute path to Datadog APM + RDCP correlation
+- **[New Relic Quickstart](examples/opentelemetry/NewRelic-Quickstart.md)** - 10-minute path to New Relic + RDCP correlation
+- **[Performance Analysis](examples/opentelemetry/Performance-Analysis.md)** - Benchmarks, overhead measurement, and production tuning
 
 ### Enterprise Deployment
-- **[Security and Compliance](enterprise/Security-and-Compliance)** - Data protection, audit trails, retention, and regulatory mapping
-- **[Operational Production Guide](enterprise/Operational-Production-Guide)** - Authentication at scale, rate limiting, multi-tenancy
-- **[Enterprise Deployment Patterns](enterprise/Enterprise-Deployment-Patterns)** - Kubernetes, service mesh, and collector architectures
+- **[Security and Compliance](enterprise/Security-and-Compliance.md)** - Data protection, audit trails, retention, and regulatory mapping
+- **[Operational Production Guide](enterprise/Operational-Production-Guide.md)** - Authentication at scale, rate limiting, multi-tenancy
+- **[Enterprise Deployment Patterns](enterprise/Enterprise-Deployment-Patterns.md)** - Kubernetes, service mesh, and collector architectures
 
 ### Authentication & Security
-- **[Authentication Setup](Authentication-Setup)** - All 3 security levels: Basic, Standard, Enterprise
-- **[Multi-Tenancy](Authentication-Setup#multi-tenancy-support)** - Tenant isolation and context management
+- **[Authentication Setup](Authentication-Setup.md)** - All 3 security levels: Basic, Standard, Enterprise
+- **[Multi-Tenancy](Authentication-Setup.md#multi-tenancy-support)** - Tenant isolation and context management
 
 ### Migration & Advanced
-- **[Migration Guide](Migration-Guide)** - Migrate from manual RDCP implementation to SDK
-- **[Client SDK](AI-Agent-Quick-Reference)** - Use the client SDK to consume RDCP endpoints
+- **[Migration Guide](Migration-Guide.md)** - Migrate from manual RDCP implementation to SDK
+- **[Client SDK](AI-Agent-Quick-Reference.md)** - Use the client SDK to consume RDCP endpoints
 - **[Protocol Compliance](../PROTOCOL-COMPLIANCE-REPORT.md)** - RDCP v1.0 protocol compliance details
 
 ### API Reference
 - **[API Documentation](https://github.com/mojoatomic/rdcp/blob/main/docs/rdcp-implementation-guide.md)** - Complete API reference and endpoint specifications
-- **[Error Handling](Authentication-Setup#error-responses)** - Standard error codes and response formats
+- **[Error Handling](Authentication-Setup.md#error-responses)** - Standard error codes and response formats
 
 ### Protocol Reference (Advanced)
 - Primary spec: [rdcp-protocol-specification.md](https://github.com/mojoatomic/rdcp/blob/main/docs/rdcp-protocol-specification.md)
@@ -174,8 +174,8 @@ MIT License - see [LICENSE](https://github.com/mojoatomic/rdcp/blob/main/LICENSE
 
 ## Next steps
 
-- Read: [AI Agent Quick Reference](AI-Agent-Quick-Reference)
-- Try: [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App)
-- Integrate: [Installation](Installation) → [Basic Usage](Basic-Usage)
-- Explore: [Trace Propagation Demo](examples/Trace-Propagation-Demo)
+- Read: [AI Agent Quick Reference](AI-Agent-Quick-Reference.md)
+- Try: [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App.md)
+- Integrate: [Installation](Installation.md) → [Basic Usage](Basic-Usage.md)
+- Explore: [Trace Propagation Demo](examples/Trace-Propagation-Demo.md)
 - Deep dive: Protocol references in docs/ (advanced)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,27 +1,27 @@
 ## RDCP SDK Documentation
 
 ### 🚀 Getting Started
-- [Home](Home)
-- [AI Agent Quick Reference](AI-Agent-Quick-Reference)
-- [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App)
-- [Installation](Installation)
-- [Basic Usage](Basic-Usage)
+- [Home](Home.md)
+- [AI Agent Quick Reference](AI-Agent-Quick-Reference.md)
+- [RDCP Demo App (In-Memory Jaeger)](examples/RDCP-Demo-App.md)
+- [Installation](Installation.md)
+- [Basic Usage](Basic-Usage.md)
 
 ### 🔐 Security & Auth
-- [Authentication Setup](Authentication-Setup)
+- [Authentication Setup](Authentication-Setup.md)
 - [Security Levels](Authentication-Setup#security-levels)
 
 ### 🔧 Advanced Usage
-- [Migration Guide](Migration-Guide) 
+- [Migration Guide](Migration-Guide.md)
 - [Multi-Tenancy](Authentication-Setup#multi-tenancy-support)
 - [Performance Metrics](Basic-Usage#performance-considerations)
 
 ### 📦 Development
-- [Implementation Status](Implementation-Status) ⚠️
-- [JavaScript vs TypeScript Boundaries](JavaScript-vs-TypeScript-Boundaries) 🔥
-- [Publishing Setup](Publishing-Setup)
+- [Implementation Status](Implementation-Status.md)
+- [JavaScript vs TypeScript Boundaries](JavaScript-vs-TypeScript-Boundaries.md)
+- [Publishing Setup](Publishing-Setup.md)
 - [Contributing](Home#how-to-contribute-to-the-docs)
-- [API Reference](../docs/rdcp-implementation-guide.md)
+- [API Reference](https://github.com/mojoatomic/rdcp/blob/main/docs/rdcp-implementation-guide.md)
 
 ### 🛠️ Framework Support
 - [Express.js](Basic-Usage#express-js)
@@ -30,12 +30,12 @@
 - [Next.js](Basic-Usage#next-js)
 
 ### 📚 Examples
-- [Trace Propagation Demo](examples/Trace-Propagation-Demo)
-- [RDCP Demo App](examples/RDCP-Demo-App)
+- [Trace Propagation Demo](examples/Trace-Propagation-Demo.md)
+- [RDCP Demo App](examples/RDCP-Demo-App.md)
 
 ### 📋 Protocol Reference
-- [Protocol Specification (docs)](../docs/rdcp-protocol-specification.md)
-- [Implementation Guide (docs)](../docs/rdcp-implementation-guide.md)
+- [Protocol Specification (docs)](https://github.com/mojoatomic/rdcp/blob/main/docs/rdcp-protocol-specification.md)
+- [Implementation Guide (docs)](https://github.com/mojoatomic/rdcp/blob/main/docs/rdcp-implementation-guide.md)
 - [Client SDK](AI-Agent-Quick-Reference)
 
 ### 🔍 Troubleshooting


### PR DESCRIPTION
This PR fixes broken wiki links in the GitHub UI by ensuring all intra-wiki links include the .md extension. Also keeps absolute links for docs under blob/main.

Changes:
- Home.md: Start Here, OpenTelemetry, Enterprise, Auth, Migration, Next steps sections
- _Sidebar.md: update entries to .md and make docs links absolute

Context:
- Repo was made public and CI + branch protection configured (CI status required). This PR should trigger CI and allow merging via PR.

Follow-ups:
- Continue sweeping for any lingering rdcp.debug.* references; examples now use debug + enableDebugCategories and setupRDCPWithOpenTelemetry().