### PR TITLE
ci: build otel-plugin before tests; explicit plugin install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
+      - run: npm ci --prefix packages/otel-plugin
+      - run: npm run build --prefix packages/otel-plugin
       - run: npm ci --prefix packages/rdcp-demo-app
       - run: npm test
       - run: npm run lint


### PR DESCRIPTION
This PR fixes CI failures due to @rdcp/otel-plugin not being built in fresh checkouts.

Changes:
- Add explicit steps in CI to `npm ci --prefix packages/otel-plugin` and `npm run build --prefix packages/otel-plugin` before tests
- Keep Node pinned via .nvmrc and explicit demo-app install step

Outcome:
- Ensures demo app tests can require @rdcp/otel-plugin without module resolution errors in CI.
