### PR TITLE
ci: build root and link @rdcp/server before building otel-plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: npm ci
+      - run: npm run build
       - run: npm ci --prefix packages/otel-plugin
+      - run: npm install --no-save --prefix packages/otel-plugin ../..
       - run: npm run build --prefix packages/otel-plugin
       - run: npm ci --prefix packages/rdcp-demo-app
       - run: npm test


### PR DESCRIPTION
Fix failing main CI:
- Build root package before building otel-plugin (generates dist types)
- Link @rdcp/server into otel-plugin node_modules (no-save) so TS resolves @rdcp/server imports during plugin build

This addresses: TS2307 Cannot find module "@rdcp/server" in otel-plugin build.