### PR TITLE
Demo App: TTL controls + hybrid hardening + docs

### DIFF
--- a/packages/rdcp-demo-app/src/app.js
+++ b/packages/rdcp-demo-app/src/app.js
@@ -227,6 +227,41 @@ function enforceControlRBAC(req, res, next) {
 // Tenant-scoped settings storage (demo only)
 const tenantSettings = new Map()
 
+// TTL timers for temporary controls per tenant/category
+const ttlTimers = new Map()
+
+function parseDurationToMs(input) {
+  if (!input) return 0
+  if (typeof input === 'number' && Number.isFinite(input)) return Math.max(0, input)
+  const s = String(input).trim()
+  const m = s.match(/^(\d+)(ms|s|m)?$/)
+  if (!m) return 0
+  const value = parseInt(m[1], 10)
+  const unit = m[2] || 'ms'
+  if (unit === 'ms') return value
+  if (unit === 's') return value * 1000
+  if (unit === 'm') return value * 60 * 1000
+  return 0
+}
+
+function scheduleCategoryTTL(tenantId, category, ms) {
+  const key = `${tenantId}:${category}`
+  // Clear any existing timer
+  const existing = ttlTimers.get(key)
+  if (existing) clearTimeout(existing)
+  if (ms <= 0) return
+  const t = setTimeout(() => {
+    try {
+      const cur = tenantSettings.get(tenantId) || { features: [], categories: [] }
+      cur.categories = (cur.categories || []).filter((c) => c !== category)
+      tenantSettings.set(tenantId, cur)
+    } finally {
+      ttlTimers.delete(key)
+    }
+  }, ms)
+  ttlTimers.set(key, t)
+}
+
 // Generic tenant RBAC middleware factory
 function requireTenantScope(scopeBase) {
   return function (req, res, next) {
@@ -278,15 +313,36 @@ app.get('/rdcp/v1/tenants/:tenantId/settings', requireTenantScope('read'), (req,
 
 app.post('/rdcp/v1/tenants/:tenantId/control', requireTenantScope('control'), (req, res) => {
   const tenantId = String(req.params.tenantId)
-  const { action, categories } = req.body || {}
+  const { action, categories, options } = req.body || {}
   const cur = tenantSettings.get(tenantId) || { features: [], categories: [] }
+  const cats = Array.isArray(categories) ? categories : []
+
   if (action === 'enable') {
-    cur.categories = Array.from(new Set([...(cur.categories || []), ...(categories || [])]))
+    cur.categories = Array.from(new Set([...(cur.categories || []), ...cats]))
+    // Handle temporary controls with TTL
+    const temporary = !!(options && options.temporary)
+    const durationMs = parseDurationToMs(options && options.duration)
+    if (temporary && durationMs > 0) {
+      for (const c of cats) scheduleCategoryTTL(tenantId, c, durationMs)
+    }
   } else if (action === 'disable') {
-    cur.categories = (cur.categories || []).filter((c) => !(categories || []).includes(c))
+    // Clear any pending TTL timers for disabled categories
+    for (const c of cats) {
+      const key = `${tenantId}:${c}`
+      const t = ttlTimers.get(key)
+      if (t) {
+        clearTimeout(t)
+        ttlTimers.delete(key)
+      }
+    }
+    cur.categories = (cur.categories || []).filter((c) => !cats.includes(c))
   }
   tenantSettings.set(tenantId, cur)
-  res.json({ success: true, tenantId, protocol: 'rdcp/1.0', requestId: req.id })
+  const response = { success: true, tenantId, protocol: 'rdcp/1.0', requestId: req.id }
+  if (options && options.temporary && options.duration) {
+    response.temporary = { enabled: true, duration: String(options.duration) }
+  }
+  res.json(response)
 })
 
 // Mount RDCP middleware (handles /.well-known/rdcp and /rdcp/v1/*)

--- a/tests/demo-app.ttl.e2e.test.js
+++ b/tests/demo-app.ttl.e2e.test.js
@@ -1,0 +1,111 @@
+const request = require('supertest')
+const jwt = require('jsonwebtoken')
+
+// Import the demo app without starting a network listener
+const { app } = require('../packages/rdcp-demo-app/src/app.js')
+
+describe('RDCP Demo App - Temporary controls (TTL)', () => {
+  const tenant = 'ttl-tenant-A'
+  const secret = process.env.JWT_SECRET || 'change-in-production'
+  const tokenCtrl = jwt.sign(
+    { sub: 'ops@example.com', scopes: ['control', `control:${tenant}`, 'read', `read:${tenant}`] },
+    secret,
+    { algorithm: 'HS256', expiresIn: '5m' }
+  )
+
+  function h(prefix = 'ttl') {
+    return {
+      'X-RDCP-Auth-Method': 'bearer',
+      'X-RDCP-Client-ID': `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+      Authorization: `Bearer ${tokenCtrl}`,
+    }
+  }
+
+  test('enable category with TTL expires after duration', async () => {
+    const resEnable = await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl1'))
+      .send({ action: 'enable', categories: ['CACHE'], options: { temporary: true, duration: '150ms' } })
+    expect(resEnable.status).toBe(200)
+
+    // Immediately present
+    const resNow = await request(app)
+      .get(`/rdcp/v1/tenants/${tenant}/settings`)
+      .set(h('ttl2'))
+    expect(resNow.status).toBe(200)
+    expect(resNow.body?.settings?.categories || []).toContain('CACHE')
+
+    // Wait for expiry
+    await new Promise(r => setTimeout(r, 220))
+
+    const resAfter = await request(app)
+      .get(`/rdcp/v1/tenants/${tenant}/settings`)
+      .set(h('ttl3'))
+    expect(resAfter.status).toBe(200)
+    expect(resAfter.body?.settings?.categories || []).not.toContain('CACHE')
+  })
+
+  test('disabling cancels pending TTL for that category', async () => {
+    // Enable with TTL
+    await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl4'))
+      .send({ action: 'enable', categories: ['API_ROUTES'], options: { temporary: true, duration: '500ms' } })
+      .expect(200)
+
+    // Disable before TTL fires
+    await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl5'))
+      .send({ action: 'disable', categories: ['API_ROUTES'] })
+      .expect(200)
+
+    await new Promise(r => setTimeout(r, 600))
+
+    const res = await request(app)
+      .get(`/rdcp/v1/tenants/${tenant}/settings`)
+      .set(h('ttl6'))
+    expect(res.status).toBe(200)
+    expect(res.body?.settings?.categories || []).not.toContain('API_ROUTES')
+  })
+
+  test('multiple categories get independent TTLs', async () => {
+    await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl7'))
+      .send({ action: 'enable', categories: ['AUTH', 'INTEGRATIONS'], options: { temporary: true, duration: '120ms' } })
+      .expect(200)
+
+    await new Promise(r => setTimeout(r, 70))
+    let res = await request(app).get(`/rdcp/v1/tenants/${tenant}/settings`).set(h('ttl8'))
+    expect(res.body?.settings?.categories || []).toEqual(expect.arrayContaining(['AUTH', 'INTEGRATIONS']))
+
+    await new Promise(r => setTimeout(r, 80))
+    res = await request(app).get(`/rdcp/v1/tenants/${tenant}/settings`).set(h('ttl9'))
+    expect(res.body?.settings?.categories || []).not.toEqual(expect.arrayContaining(['AUTH', 'INTEGRATIONS']))
+  })
+
+  test('TTL applies only when options.temporary is true and duration is valid', async () => {
+    await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl10'))
+      .send({ action: 'enable', categories: ['REPORTS'], options: { temporary: false, duration: '100ms' } })
+      .expect(200)
+
+    await new Promise(r => setTimeout(r, 160))
+    const res = await request(app).get(`/rdcp/v1/tenants/${tenant}/settings`).set(h('ttl11'))
+    expect(res.body?.settings?.categories || []).toContain('REPORTS')
+  })
+
+  test('invalid or zero durations do not schedule TTL', async () => {
+    await request(app)
+      .post(`/rdcp/v1/tenants/${tenant}/control`)
+      .set(h('ttl12'))
+      .send({ action: 'enable', categories: ['QUERIES'], options: { temporary: true, duration: 'xyz' } })
+      .expect(200)
+
+    await new Promise(r => setTimeout(r, 150))
+    const res = await request(app).get(`/rdcp/v1/tenants/${tenant}/settings`).set(h('ttl13'))
+    expect(res.body?.settings?.categories || []).toContain('QUERIES')
+  })
+})


### PR DESCRIPTION
This PR adds:

- TTL (temporary controls) for tenant-scoped categories in the demo app
  - Per-category timers; cancel on disable; duration supports ms|s|m
  - New e2e tests covering TTL expiry, cancel-on-disable, independent timers
- Hybrid hardening negative: invalid certificate (disallowed subject) + valid JWT still returns 401 (no bypass)
- Cross-links in Authentication wiki to error-responses and testing-helpers
- Verification: scripts/ci-local.sh (tests, type-check, lint) all green locally (184 tests, 16 suites)

Scope is docs + demo app only; no breaking changes to SDK APIs.