### PR TITLE
docs(context7): exclude WARP.md and warp-generic.md

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -52,7 +52,9 @@
     "license.md",
     "CODE_OF_CONDUCT.md",
     "code_of_conduct.md",
-    "README-Wiki-Setup.md"
+    "README-Wiki-Setup.md",
+    "WARP.md",
+    "warp-generic.md"
   ],
   "rules": [
     "Use the '@rdcp.dev/server' package (not '@rdcp/server')",


### PR DESCRIPTION
Exclude WARP.md and warp-generic.md from Context7 indexing via context7.json (main repo). The docs-only scope remains (folders: ["docs"]). This keeps Context7 snippets focused on the canonical protocol and implementation docs.