### PR TITLE
docs(core): document @rdcp.dev/core boundaries and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 - JWKS Integration (wiki): https://github.com/mojoatomic/rdcp/wiki/JWKS
 - JWKS Client Quickstart (repo): docs/jwks-client.md
 - JWKS Cache Stores (repo): docs/jwks-cache-stores.md
+- Core package boundaries (repo): docs/core-package-boundaries.md
 - Rate Limiting: https://github.com/mojoatomic/rdcp/wiki/Rate-Limiting
 - API Reference: https://github.com/mojoatomic/rdcp/wiki/API-Reference
 - OpenTelemetry Plugin: https://github.com/mojoatomic/rdcp/wiki/OpenTelemetry-Integration-Roadmap

--- a/docs/core-package-boundaries.md
+++ b/docs/core-package-boundaries.md
@@ -1,0 +1,36 @@
+# @rdcp.dev/core package boundaries
+
+Purpose
+
+- Provide a single, framework-agnostic source of truth for RDCP protocol types
+- Eliminate duplicate type definitions across server/client/agents
+- Keep server implementation details decoupled from protocol surface
+
+Boundaries
+
+- Types only, no runtime code
+- No Node.js, DOM, or framework dependencies
+- No imports from @rdcp.dev/server (or adapters)
+- Stable union types for error codes and protocol fields; no any types
+
+Import guidance
+
+- Prefer importing shared RDCP protocol types from @rdcp.dev/core
+- Keep server-specific utilities in @rdcp.dev/server
+- If a utility is broadly useful and has no runtime/platform coupling, consider promoting it here (in a later PR)
+
+Example
+
+```ts
+import type { ControlRequest, RDCPErrorCode } from '@rdcp.dev/core'
+
+export function validate(req: ControlRequest): RDCPErrorCode | undefined {
+  //... validate against protocol-specified fields
+  return undefined
+}
+```
+
+Related docs
+
+- packages/rdcp-core/README.md (package overview)
+- docs/rdcp-protocol-specification.md (protocol spec)

--- a/packages/rdcp-core/README.md
+++ b/packages/rdcp-core/README.md
@@ -1,0 +1,36 @@
+# @rdcp.dev/core
+
+Protocol types for RDCP shared across server and client packages.
+
+What this package contains
+- Stable protocol-facing TypeScript types (no any types)
+- Zero runtime logic (types only)
+- No framework or Node.js coupling
+- Minimal surface intended for broad reuse (SDKs, agents, services)
+
+Design boundaries
+- Import-only: consumers should import types from @rdcp.dev/core; no side effects
+- No runtime utilities or environment-specific code
+- No Node.js built-ins, no fetch/http usage, no file I/O
+- No dependency on @rdcp.dev/server or any adapter packages
+
+Usage
+
+```ts
+import type { RDCPErrorCode, ControlRequest, DiscoveryDocument } from '@rdcp.dev/core'
+
+function handleControl(req: ControlRequest): { error?: RDCPErrorCode } {
+  // ... service implementation using shared protocol types
+  return {}
+}
+```
+
+Versioning
+- Additive changes (new types/fields) follow semver minor
+- Breaking type changes follow semver major
+- Avoid removing/renaming existing fields; prefer deprecation comments first
+
+Contributing
+- Keep the surface minimal and focused on protocol representations
+- Follow strict TypeScript: no any, prefer precise string unions and readonly where appropriate
+- Align with the RDCP protocol docs (docs/rdcp-protocol-specification.md)


### PR DESCRIPTION
Adds repo-local documentation for the new @rdcp.dev/core package:

- packages/rdcp-core/README.md (package overview, constraints, usage)
- docs/core-package-boundaries.md (guidance for imports and scope)
- README: link to the boundaries doc in Documentation section

Docs-only PR – no code changes. CI-local build/tests type-check/lint passed.