### PR TITLE
docs(spec): sync protocol spec with core schemas; add generated error-codes doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 - JWKS Client Quickstart (repo): docs/jwks-client.md
 - JWKS Cache Stores (repo): docs/jwks-cache-stores.md
 - Protocol schemas (repo): docs/protocol-schemas.md
+- Protocol error codes (repo): docs/error-codes.md
 - Core package boundaries (repo): docs/core-package-boundaries.md
 - Rate Limiting: https://github.com/mojoatomic/rdcp/wiki/Rate-Limiting
 - API Reference: https://github.com/mojoatomic/rdcp/wiki/API-Reference

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,30 @@
+# RDCP Protocol Error Codes
+
+This file is generated. Do not edit manually.
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `RDCP_AUDIT_WRITE_FAILED` | 500 | Audit write failed |
+| `RDCP_AUTH_REQUIRED` | 401 | Authentication required |
+| `RDCP_CATEGORY_NOT_FOUND` | 404 | Category not found |
+| `RDCP_CONFIGURATION_ERROR` | 500 | Configuration error |
+| `RDCP_FORBIDDEN` | 403 | Insufficient permissions |
+| `RDCP_INTERNAL_ERROR` | 500 | Internal server error |
+| `RDCP_INVALID_ACTION` | 400 | Invalid control action |
+| `RDCP_INVALID_CATEGORY` | 400 | Invalid category specified |
+| `RDCP_INVALID_CLIENT` | 403 | Invalid client or credentials |
+| `RDCP_INVALID_PROTOCOL` | 400 | Unsupported or invalid protocol usage |
+| `RDCP_INVALID_TOKEN` | 401 | Token invalid |
+| `RDCP_MALFORMED_REQUEST` | 400 | Malformed request payload |
+| `RDCP_MISSING_PARAMETER` | 400 | Required parameter missing |
+| `RDCP_NOT_FOUND` | 404 | Resource not found |
+| `RDCP_RATE_LIMITED` | 429 | Rate limit exceeded |
+| `RDCP_RATE_LIMIT_MISCONFIGURED` | 500 | Rate limit configuration error |
+| `RDCP_REQUEST_ID_INVALID` | 400 | Invalid request identifier |
+| `RDCP_SERVER_ERROR` | 500 | Server error |
+| `RDCP_STORAGE_ERROR` | 500 | Storage error |
+| `RDCP_TIMEOUT` | 504 | Request timed out |
+| `RDCP_TOKEN_EXPIRED` | 401 | Token expired |
+| `RDCP_UNAVAILABLE` | 503 | Service unavailable |
+| `RDCP_UNSUPPORTED_VERSION` | 400 | Unsupported protocol version |
+| `RDCP_VALIDATION_ERROR` | 400 | Request validation failed |

--- a/docs/rdcp-protocol-specification.md
+++ b/docs/rdcp-protocol-specification.md
@@ -289,10 +289,10 @@ X-RDCP-Tenant-ID: <tenant-id>  # If multi-tenant
   "timestamp": "2025-09-17T10:30:00Z",
   "categories": [
     {
-      "id": "DATABASE",
-      "enabled": true|false,
+      "name": "DATABASE",
       "description": "Database operations",
-      "tags": ["infrastructure"],
+      "enabled": true,
+      "temporary": false,
       "metrics": {
         "callsTotal": 1234,
         "callsPerSecond": 2.3
@@ -300,18 +300,9 @@ X-RDCP-Tenant-ID: <tenant-id>  # If multi-tenant
     }
   ],
   "performance": {
-    "overhead": {
-      "cpu": {
-        "value": 0.1,
-        "unit": "percent",
-        "measured": true|false
-      },
-      "memory": {
-        "value": 1048576,
-        "unit": "bytes",
-        "measured": true|false
-      }
-    }
+    "totalCalls": 45678,
+    "callsPerSecond": 2.3,
+    "categoryBreakdown": { "DATABASE": 1234 }
   }
 }
 ```
@@ -322,14 +313,14 @@ X-RDCP-Tenant-ID: <tenant-id>  # If multi-tenant
 ```json
 POST /rdcp/v1/control HTTP/1.1
 Content-Type: application/json
-X-RDCP-Request-ID: <unique-id>  # OPTIONAL
 
 {
-  "action": "enable|disable|toggle|reset",
-  "categories": ["DATABASE"] | "*",
+  "action": "enable|disable|toggle|reset|status",
+  "categories": ["DATABASE", "API_ROUTES"]  // or a single string "DATABASE"
+  ,
   "options": {
-    "temporary": true|false,
-    "duration": 300,  # seconds
+    "temporary": true,
+    "duration": "15m",  // number (seconds) or duration string (e.g., "15m")
     "reason": "Investigating issue #1234"
   }
 }
@@ -339,35 +330,21 @@ X-RDCP-Request-ID: <unique-id>  # OPTIONAL
 ```json
 {
   "protocol": "rdcp/1.0",
-  "requestId": "<request-id>",
-  "success": true|false,
-  "authContext": {
-    "method": "bearer",
-    "userId": "user@example.com",
-    "scopes": ["control"],
-    "sessionId": "sess_abc123"
-  },
+  "timestamp": "2025-09-17T10:30:00Z",
+  "action": "enable",
+  "categories": ["DATABASE"],
+  "status": "success", // "partial" or "failed"
+  "message": "Enabled categories",
   "changes": [
     {
       "category": "DATABASE",
       "previousState": false,
       "newState": true,
+      "temporary": true,
       "effectiveAt": "2025-09-17T10:30:00Z",
-      "expiresAt": "2025-09-17T10:35:00Z"  # If temporary
+      "expiresAt": "2025-09-17T10:45:00Z"
     }
-  ],
-  "audit": {
-    "timestamp": "2025-09-17T10:30:00Z",
-    "action": "enable",
-    "operator": "user@example.com",
-    "method": "bearer",
-    "clientId": "admin-console-v1",
-    "reason": "Investigating issue #1234",
-    "complianceMetadata": {  # For enterprise level
-      "ticketId": "INC-1234",
-      "approvedBy": "manager@example.com"
-    }
-  }
+  ]
 }
 ```
 
@@ -383,16 +360,9 @@ GET /rdcp/v1/status HTTP/1.1
 {
   "protocol": "rdcp/1.0",
   "timestamp": "2025-09-17T10:30:00Z",
-  "categories": {
-    "DATABASE": {
-      "enabled": true,
-      "metrics": {
-        "callsLastMinute": 123,
-        "callsTotal": 45678,
-        "lastActivity": "2025-09-17T10:29:55Z"
-      }
-    }
-  }
+  "enabled": true,
+  "categories": { "DATABASE": true, "API_ROUTES": false },
+  "performance": { "totalCalls": 45678, "callsPerSecond": 2.3 }
 }
 ```
 
@@ -407,12 +377,12 @@ GET /rdcp/v1/health HTTP/1.1
 ```json
 {
   "protocol": "rdcp/1.0",
-  "status": "healthy|degraded|unhealthy",
   "timestamp": "2025-09-17T10:30:00Z",
-  "components": {
-    "debugSystem": "operational|degraded|failed",
-    "persistence": "operational|degraded|failed"
-  }
+  "status": "healthy",
+  "checks": [
+    { "name": "redis", "status": "pass", "duration": "5ms" },
+    { "name": "db", "status": "pass", "duration": "8ms" }
+  ]
 }
 ```
 
@@ -437,15 +407,7 @@ All errors MUST follow:
 
 ### 6.2 Standard Error Codes
 
-| Code | HTTP Status | Description |
-|------|-------------|-------------|
-| `RDCP_AUTH_REQUIRED` | 401 | Authentication required |
-| `RDCP_FORBIDDEN` | 403 | Insufficient permissions |
-| `RDCP_NOT_FOUND` | 404 | Resource not found |
-| `RDCP_VALIDATION_ERROR` | 400 | Request validation failed |
-| `RDCP_CATEGORY_NOT_FOUND` | 400 | Invalid category specified |
-| `RDCP_RATE_LIMITED` | 429 | Rate limit exceeded |
-| `RDCP_INTERNAL_ERROR` | 500 | Internal server error |
+For the complete, source-of-truth list of protocol error codes and their HTTP mappings, see: docs/error-codes.md
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     }
   },
   "scripts": {
+    "gen:error-codes": "npm run build && node scripts/generate-error-codes-doc.mjs",
     "docs:check-links": "node scripts/check-wiki-links.js",
     "docs:check-links:external": "node scripts/check-wiki-links.js --external",
     "dev": "tsx watch examples/express-server.ts",

--- a/scripts/generate-error-codes-doc.mjs
+++ b/scripts/generate-error-codes-doc.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function main() {
+  // Import built dist (CJS) to read constants from runtime
+  const distPath = path.resolve(__dirname, '../dist/index.js')
+  const modNs = await import(`file://${distPath}`)
+  const mod = modNs.RDCP_ERROR_CODES ? modNs : (modNs.default ?? {})
+
+  const { RDCP_ERROR_CODES, ERROR_STATUS_MAP } = mod
+  if (!RDCP_ERROR_CODES || !ERROR_STATUS_MAP) {
+    console.error('Could not load RDCP_ERROR_CODES or ERROR_STATUS_MAP from dist. Run `npm run build` first.')
+    process.exit(1)
+  }
+
+  // Human descriptions (extend as needed)
+  const DESCRIPTIONS = {
+    RDCP_AUTH_REQUIRED: 'Authentication required',
+    RDCP_INVALID_TOKEN: 'Token invalid',
+    RDCP_TOKEN_EXPIRED: 'Token expired',
+    RDCP_FORBIDDEN: 'Insufficient permissions',
+    RDCP_INVALID_CLIENT: 'Invalid client or credentials',
+    RDCP_VALIDATION_ERROR: 'Request validation failed',
+    RDCP_INVALID_ACTION: 'Invalid control action',
+    RDCP_INVALID_CATEGORY: 'Invalid category specified',
+    RDCP_CATEGORY_NOT_FOUND: 'Category not found',
+    RDCP_MISSING_PARAMETER: 'Required parameter missing',
+    RDCP_INVALID_PROTOCOL: 'Unsupported or invalid protocol usage',
+    RDCP_NOT_FOUND: 'Resource not found',
+    RDCP_RATE_LIMITED: 'Rate limit exceeded',
+    RDCP_REQUEST_ID_INVALID: 'Invalid request identifier',
+    RDCP_MALFORMED_REQUEST: 'Malformed request payload',
+    RDCP_UNSUPPORTED_VERSION: 'Unsupported protocol version',
+    RDCP_SERVER_ERROR: 'Server error',
+    RDCP_INTERNAL_ERROR: 'Internal server error',
+    RDCP_UNAVAILABLE: 'Service unavailable',
+    RDCP_TIMEOUT: 'Request timed out',
+    RDCP_CONFIGURATION_ERROR: 'Configuration error',
+    RDCP_STORAGE_ERROR: 'Storage error',
+    RDCP_AUDIT_WRITE_FAILED: 'Audit write failed',
+    RDCP_RATE_LIMIT_MISCONFIGURED: 'Rate limit configuration error',
+  }
+
+  // Build rows from map, ensuring stable sort
+  const entries = Object.keys(RDCP_ERROR_CODES)
+    .sort()
+    .map(k => RDCP_ERROR_CODES[k])
+    .map(code => {
+      const status = ERROR_STATUS_MAP[code] ?? ''
+      const desc = DESCRIPTIONS[code] ?? ''
+      return { code, status, desc }
+    })
+
+  const out = []
+  out.push('# RDCP Protocol Error Codes')
+  out.push('')
+  out.push('This file is generated. Do not edit manually.')
+  out.push('')
+  out.push('| Code | HTTP Status | Description |')
+  out.push('|------|-------------|-------------|')
+  for (const { code, status, desc } of entries) {
+    out.push(`| \`${code}\` | ${status} | ${desc} |`)
+  }
+  out.push('')
+
+  const outPath = path.resolve(__dirname, '../docs/error-codes.md')
+  fs.writeFileSync(outPath, out.join('\n'))
+  console.log(`Wrote ${outPath}`)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export {
   safeValidate,
   // Error handling
   RDCP_ERROR_CODES,
+  ERROR_STATUS_MAP,
   createRDCPError,
   createRDCPErrorWithStatus,
   createValidationError,


### PR DESCRIPTION
Summary

- Sync docs/rdcp-protocol-specification.md with @rdcp.dev/core schemas:
  - Control request: include "status" action; categories accept string or string[]
  - Control response: use status (success|partial|failed) and changes[] structure; remove legacy success/authContext fields
  - Discovery response: align fields (name/description/enabled/metrics) and performance object
  - Status/Health: align with schemas (categories record, performance; checks[] for health)
- Add generated docs/error-codes.md from code (RDCP_ERROR_CODES + ERROR_STATUS_MAP)
  - New script: scripts/generate-error-codes-doc.mjs
  - NPM script: gen:error-codes
- Link error-codes doc from spec and README

Verification

- Build + tests: 34/34 passed, 222 tests
- Type-check + eslint (CI-local) succeeded

Notes

- The control response example reflects the core schema. Some demo endpoint code still returns a legacy shape; follow-up PR can update the demo endpoint or we can keep it as an example while the protocol schema is the source of truth.