### PR TITLE
docs/pr12 readme core imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - run: npm ci
+      - run: npm ci --no-audit --no-fund
       - run: npm run build
       - run: npm install --prefix packages/otel-plugin --no-audit --no-fund
       - run: npm install --no-save --prefix packages/otel-plugin $GITHUB_WORKSPACE
       - run: npm run build --prefix packages/otel-plugin
       - run: npm install --prefix packages/rdcp-demo-app --no-audit --no-fund
       - run: npm test
-      - run: npm run lint
+      - run: npm run lint:ci

--- a/.github/workflows/error-codes-drift.yml
+++ b/.github/workflows/error-codes-drift.yml
@@ -1,0 +1,26 @@
+name: Error Codes Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install deps (clean)
+        run: npm ci --no-audit --no-fund
+
+      - name: Generate error-codes doc
+        run: npm run gen:error-codes
+
+      - name: Check for drift
+        run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ curl -X POST /rdcp/v1/control \
 
 ---
 
+## Quick imports from @rdcp.dev/core
+
+Use these imports to access protocol constants and shared definitions from the core package:
+
+```ts path=null start=null
+import { PROTOCOL_VERSION, RDCP_PATHS } from '@rdcp.dev/core'
+import { RDCP_ERROR_CODES } from '@rdcp.dev/core'
+// If exported in your version of core:
+// import { controlRequestSchema } from '@rdcp.dev/core'
+```
+
 ## Framework Integration
 
 ### Express.js

--- a/packages/otel-plugin/eslint.config.mjs
+++ b/packages/otel-plugin/eslint.config.mjs
@@ -1,0 +1,29 @@
+import { defineConfig } from 'eslint/config'
+import js from '@eslint/js'
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
+
+export default defineConfig([
+  {
+    ignores: ['dist/', 'node_modules/']
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin
+    },
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }]
+    }
+  }
+])

--- a/packages/otel-plugin/package.json
+++ b/packages/otel-plugin/package.json
@@ -68,9 +68,9 @@
   "devDependencies": {
     "@types/jest": "^29.5.0",
     "@types/node": "^20.10.6",
-    "@typescript-eslint/eslint-plugin": "^6.16.0",
-    "@typescript-eslint/parser": "^6.16.0",
-    "eslint": "^8.56.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
- **ci: use local ESLint v9 and add error-codes drift check; upgrade otel-plugin dev ESLint to v9**
- **docs: add quick imports section for @rdcp.dev/core to README**
