### PR TITLE
chore(core): publish readiness (files/types/sideEffects + LICENSE); no code changes

### DIFF
--- a/packages/rdcp-core/LICENSE
+++ b/packages/rdcp-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Doug Fennell/rdcp.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rdcp-core/package.json
+++ b/packages/rdcp-core/package.json
@@ -4,6 +4,14 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "dist-cjs",
+    "README.md",
+    "LICENSE"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.esm.js",


### PR DESCRIPTION
Prepping @rdcp.dev/core for eventual publish:
- add files array to restrict tarball (dist, dist-cjs, README.md, LICENSE)
- add types and sideEffects fields
- include LICENSE

No runtime code changes.

Dry-run pack confirms only dist assets and docs are included.