### PR TITLE
feat(client): scaffold @rdcp.dev/client (native fetch, typed endpoints, error mapping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ npm-debug.log*
 
 # Build outputs
 dist/
+dist-cjs/
 build/
 coverage/
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import prettierPlugin from 'eslint-plugin-prettier'
 export default defineConfig([
   {
     // ignore patterns (must be in a standalone object in flat config)
-    ignores: ['dist/', 'coverage/', 'node_modules/', '*.config.js', '*.config.ts'],
+    ignores: ['dist/', 'dist-cjs/', 'coverage/', 'node_modules/', '*.config.js', '*.config.ts'],
   },
   js.configs.recommended,
   {

--- a/packages/rdcp-client/LICENSE
+++ b/packages/rdcp-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Doug Fennell/rdcp.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/rdcp-client/README.md
+++ b/packages/rdcp-client/README.md
@@ -1,0 +1,43 @@
+# @rdcp.dev/client
+
+Typed RDCP client SDK for Node 18+ and modern browsers. Uses native fetch; no polyfills.
+
+- Node.js 18+ (native fetch)
+- Browsers (native fetch)
+
+## Install
+
+```
+npm install @rdcp.dev/client @rdcp.dev/core zod
+```
+
+## Quick start
+
+```ts
+import { createRDCPClient } from '@rdcp.dev/client'
+
+const rdcp = createRDCPClient({ baseUrl: 'http://localhost:3000' })
+
+const discovery = await rdcp.getDiscovery()
+const status = await rdcp.getStatus()
+await rdcp.postControl({ action: 'enable', categories: ['DATABASE'] })
+```
+
+## API
+
+- createRDCPClient(options)
+  - options.baseUrl: string
+  - options.headers?: Record<string, string>
+  - options.fetch?: typeof fetch (optional override)
+
+Methods:
+- getDiscovery(): Promise<DiscoveryResponse>
+- getStatus(): Promise<StatusResponse>
+- postControl(body: ControlRequest): Promise<ControlResponse>
+
+## Errors
+
+Errors are thrown as RDCPClientError with fields:
+- code?: RDCP error code (string)
+- status?: HTTP status
+- details?: unknown

--- a/packages/rdcp-client/package-lock.json
+++ b/packages/rdcp-client/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rdcp.dev/client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rdcp.dev/client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rdcp.dev/core": "file:../rdcp-core",
+        "zod": "^3.24.2"
+      }
+    },
+    "../rdcp-core": {
+      "name": "@rdcp.dev/core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@rdcp.dev/core": {
+      "resolved": "../rdcp-core",
+      "link": true
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/rdcp-client/package.json
+++ b/packages/rdcp-client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rdcp.dev/client",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "dist-cjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist-cjs/index.js",
+      "types": "./dist/index.d.ts",
+      "default": "./dist-cjs/index.js"
+    }
+  },
+  "dependencies": {
+    "@rdcp.dev/core": "file:../rdcp-core",
+    "zod": "^3.24.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.cjs.json"
+  }
+}

--- a/packages/rdcp-client/src/index.ts
+++ b/packages/rdcp-client/src/index.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod'
+import {
+  discoveryResponseSchema,
+  statusResponseSchema,
+  controlRequestSchema,
+  controlResponseSchema,
+  errorResponseSchema,
+} from '@rdcp.dev/core'
+
+export interface RDCPClientOptions {
+  baseUrl: string
+  headers?: Record<string, string>
+  fetch?: typeof fetch
+}
+
+export class RDCPClientError extends Error {
+  readonly code?: string
+  readonly status?: number
+  readonly details?: unknown
+  constructor(
+    message: string,
+    code?: string,
+    status?: number,
+    details?: unknown
+  ) {
+    super(message)
+    if (code !== undefined) this.code = code
+    if (status !== undefined) this.status = status
+    if (details !== undefined) this.details = details
+  }
+}
+
+async function doFetch<T>(
+  f: typeof fetch,
+  url: string,
+  init: RequestInit,
+  schema: z.ZodSchema<T>
+): Promise<T> {
+  const res = await f(url, init)
+  const txt = await res.text()
+  const contentType = res.headers.get('content-type') ?? ''
+  const maybeJson = contentType.includes('application/json')
+  const body = maybeJson && txt ? JSON.parse(txt) : undefined
+
+  if (!res.ok) {
+    let code: string | undefined
+    if (body) {
+      const parsed = errorResponseSchema.safeParse(body)
+      if (parsed.success) code = parsed.data.error.code
+    }
+    throw new RDCPClientError('RDCP request failed', code, res.status, body)
+  }
+
+  const parsed = schema.safeParse(body)
+  if (!parsed.success) {
+    throw new RDCPClientError(
+      'Invalid RDCP response',
+      'RDCP_VALIDATION_ERROR',
+      res.status,
+      parsed.error
+    )
+  }
+  return parsed.data
+}
+
+export interface RDCPClient {
+  getDiscovery: () => Promise<z.infer<typeof discoveryResponseSchema>>
+  getStatus: () => Promise<z.infer<typeof statusResponseSchema>>
+  postControl: (
+    body: z.infer<typeof controlRequestSchema>
+  ) => Promise<z.infer<typeof controlResponseSchema>>
+}
+
+export function createRDCPClient(options: RDCPClientOptions): RDCPClient {
+  const f = options.fetch ?? fetch
+  const base = options.baseUrl.replace(/\/$/, '')
+  const baseHeaders = options.headers ?? {}
+
+  return {
+    async getDiscovery(): Promise<z.infer<typeof discoveryResponseSchema>> {
+      const url = `${base}/rdcp/v1/discovery`
+      return doFetch(
+        f,
+        url,
+        { method: 'GET', headers: { ...baseHeaders } },
+        discoveryResponseSchema
+      )
+    },
+    async getStatus(): Promise<z.infer<typeof statusResponseSchema>> {
+      const url = `${base}/rdcp/v1/status`
+      return doFetch(
+        f,
+        url,
+        { method: 'GET', headers: { ...baseHeaders } },
+        statusResponseSchema
+      )
+    },
+    async postControl(
+      body: z.infer<typeof controlRequestSchema>
+    ): Promise<z.infer<typeof controlResponseSchema>> {
+      const url = `${base}/rdcp/v1/control`
+      const parsed = controlRequestSchema.safeParse(body)
+      if (!parsed.success) {
+        throw new RDCPClientError(
+          'Invalid control request',
+          'RDCP_VALIDATION_ERROR',
+          0,
+          parsed.error
+        )
+      }
+      return doFetch(
+        f,
+        url,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', ...baseHeaders },
+          body: JSON.stringify(parsed.data),
+        },
+        controlResponseSchema
+      )
+    },
+  }
+}

--- a/packages/rdcp-client/tsconfig.cjs.json
+++ b/packages/rdcp-client/tsconfig.cjs.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist-cjs",
+    "module": "commonjs",
+    "target": "es2022",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@rdcp.dev/core": ["../rdcp-core/dist/index.d.ts"]
+    },
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/rdcp-client/tsconfig.json
+++ b/packages/rdcp-client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "es2022",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@rdcp.dev/core": ["../rdcp-core/dist/index.d.ts"]
+    },
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Scaffolds the RDCP client SDK for Node 18+ and browsers.

- Native fetch (no polyfills; Node 18+ required)
- Typed endpoints using @rdcp.dev/core zod schemas
- Error mapping to RDCPClientError
- ESM + CJS outputs via dual tsconfig (no rollup)
- .d.ts emitted alongside JS per build step

No integration tests yet; initial minimal tests can be added in a follow-up.
