### PR TITLE
chore(server): use @rdcp.dev/core ^1.0.0 (post-publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "*.md": "node scripts/check-wiki-links.js"
   },
   "dependencies": {
-    "@rdcp.dev/core": "file:packages/rdcp-core",
+    "@rdcp.dev/core": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
     "fastify-plugin": "^5.0.1",
     "jose": "^5.9.4",


### PR DESCRIPTION
Switch server dependency from file:packages/rdcp-core to ^1.0.0 now that core is published.\n\n- Keeps server version at 2.1.0 (no functional changes)\n- Unblocks fresh installs from npm\n- Verified builds and tests previously in release PR\n\nMerge this before publishing @rdcp.dev/server.