### PR TITLE
docs: post-publish updates (badges, install, status summary)

### DIFF
--- a/IMPLEMENTATION-STATUS-SUMMARY.md
+++ b/IMPLEMENTATION-STATUS-SUMMARY.md
@@ -1,8 +1,8 @@
 # RDCP SDK Implementation Status Summary
 
 **Project**: RDCP SDK (Runtime Debug Control Protocol v1.0)  
-**Analysis Date**: 2025-01-27  
-**Current Version**: 1.0.0  
+**Analysis Date**: 2025-09-25  
+**Current Versions**: core 1.0.0, client 1.0.0, server 2.1.0  
 
 ---
 
@@ -11,7 +11,7 @@
 The RDCP SDK project is **production-ready** and achieves **Level 2: Standard compliance** with the RDCP v1.0 Protocol Specification. It provides a comprehensive TypeScript/JavaScript SDK for implementing runtime debug control capabilities in Node.js applications.
 
 ### Key Achievements ✅
-- **130 passing tests** across 11 test suites
+- **226 passing tests** across 35 test suites
 - **Full protocol compliance** with all required RDCP v1.0 endpoints
 - **Multi-framework support** (Express, Fastify, Koa, Next.js)
 - **Complete authentication system** supporting all 3 security levels
@@ -63,7 +63,7 @@ The RDCP SDK project is **production-ready** and achieves **Level 2: Standard co
 
 ## 🧪 Testing Status
 
-### Test Coverage: **130 Tests Passing** ✅
+### Test Coverage: **226 Tests Passing** ✅
 
 | Test Suite | Tests | Status | Coverage |
 |------------|-------|--------|----------|

--- a/README.md
+++ b/README.md
@@ -2,12 +2,27 @@
 
 First-of-its-kind JavaScript/TypeScript SDK implementing the Runtime Debug Control Protocol (RDCP) for operational infrastructure control.
 
-[![npm version](https://badge.fury.io/js/@rdcp.dev%2Fserver.svg)](https://badge.fury.io/js/@rdcp.dev%2Fserver)
+[![npm: @rdcp.dev/core](https://img.shields.io/npm/v/%40rdcp.dev/core?label=%40rdcp.dev%2Fcore)](https://www.npmjs.com/package/@rdcp.dev/core)
+[![npm: @rdcp.dev/client](https://img.shields.io/npm/v/%40rdcp.dev/client?label=%40rdcp.dev%2Fclient)](https://www.npmjs.com/package/@rdcp.dev/client)
+[![npm: @rdcp.dev/server](https://img.shields.io/npm/v/%40rdcp.dev/server?label=%40rdcp.dev%2Fserver)](https://www.npmjs.com/package/@rdcp.dev/server)
 [![CI](https://github.com/mojoatomic/rdcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mojoatomic/rdcp/actions/workflows/ci.yml)
 [![Protocol Compliance](https://img.shields.io/badge/RDCP-v1.0%20Compliant-green)](https://github.com/mojoatomic/rdcp/blob/main/PROTOCOL-COMPLIANCE-REPORT.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ---
+
+## Install
+
+```bash
+# Core (protocol constants, error codes, schemas)
+npm i @rdcp.dev/core
+
+# Client SDK (fetch-based, Node 18+)
+npm i @rdcp.dev/client
+
+# Server SDK (adapters, endpoints, auth)
+npm i @rdcp.dev/server
+```
 
 ## The Infrastructure Gap
 


### PR DESCRIPTION
This PR updates documentation after publishing the RDCP ecosystem.

- README: adds npm badges for core/client/server and an Install section for quick copy/paste
- IMPLEMENTATION-STATUS-SUMMARY.md: updates analysis date, versions, coverage headline (226 tests / 35 suites), and notes full client–server SDK ecosystem
- Package READMEs: add npm badges to @rdcp.dev/core and @rdcp.dev/client
- Wiki (pushed separately): badges and install snippets + What's New (v1.0/v2.1) highlighting complete ecosystem

After merge, the README and status will present clear install commands and accurate state.