### PR TITLE
feat(demo): client-first demo scripts and npm commands (#75)

### DIFF
--- a/IMPLEMENTATION-STATUS-SUMMARY.md
+++ b/IMPLEMENTATION-STATUS-SUMMARY.md
@@ -1,8 +1,8 @@
 # RDCP SDK Implementation Status Summary
 
 **Project**: RDCP SDK (Runtime Debug Control Protocol v1.0)  
-**Analysis Date**: 2025-01-27  
-**Current Version**: 1.0.0  
+**Analysis Date**: 2025-09-25  
+**Current Versions**: core 1.0.0, client 1.0.0, server 2.1.0  
 
 ---
 
@@ -11,7 +11,7 @@
 The RDCP SDK project is **production-ready** and achieves **Level 2: Standard compliance** with the RDCP v1.0 Protocol Specification. It provides a comprehensive TypeScript/JavaScript SDK for implementing runtime debug control capabilities in Node.js applications.
 
 ### Key Achievements ✅
-- **130 passing tests** across 11 test suites
+- **226 passing tests** across 35 test suites
 - **Full protocol compliance** with all required RDCP v1.0 endpoints
 - **Multi-framework support** (Express, Fastify, Koa, Next.js)
 - **Complete authentication system** supporting all 3 security levels
@@ -63,7 +63,7 @@ The RDCP SDK project is **production-ready** and achieves **Level 2: Standard co
 
 ## 🧪 Testing Status
 
-### Test Coverage: **130 Tests Passing** ✅
+### Test Coverage: **226 Tests Passing** ✅
 
 | Test Suite | Tests | Status | Coverage |
 |------------|-------|--------|----------|

--- a/README.md
+++ b/README.md
@@ -2,12 +2,27 @@
 
 First-of-its-kind JavaScript/TypeScript SDK implementing the Runtime Debug Control Protocol (RDCP) for operational infrastructure control.
 
-[![npm version](https://badge.fury.io/js/@rdcp.dev%2Fserver.svg)](https://badge.fury.io/js/@rdcp.dev%2Fserver)
+[![npm: @rdcp.dev/core](https://img.shields.io/npm/v/%40rdcp.dev/core?label=%40rdcp.dev%2Fcore)](https://www.npmjs.com/package/@rdcp.dev/core)
+[![npm: @rdcp.dev/client](https://img.shields.io/npm/v/%40rdcp.dev/client?label=%40rdcp.dev%2Fclient)](https://www.npmjs.com/package/@rdcp.dev/client)
+[![npm: @rdcp.dev/server](https://img.shields.io/npm/v/%40rdcp.dev/server?label=%40rdcp.dev%2Fserver)](https://www.npmjs.com/package/@rdcp.dev/server)
 [![CI](https://github.com/mojoatomic/rdcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mojoatomic/rdcp/actions/workflows/ci.yml)
 [![Protocol Compliance](https://img.shields.io/badge/RDCP-v1.0%20Compliant-green)](https://github.com/mojoatomic/rdcp/blob/main/PROTOCOL-COMPLIANCE-REPORT.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ---
+
+## Install
+
+```bash
+# Core (protocol constants, error codes, schemas)
+npm i @rdcp.dev/core
+
+# Client SDK (fetch-based, Node 18+)
+npm i @rdcp.dev/client
+
+# Server SDK (adapters, endpoints, auth)
+npm i @rdcp.dev/server
+```
 
 ## The Infrastructure Gap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@rdcp.dev/server",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rdcp.dev/server",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@rdcp.dev/core": "file:packages/rdcp-core",
+        "@rdcp.dev/core": "^1.0.0",
         "fastify-plugin": "^5.0.1",
         "jose": "^5.9.4",
         "jsonwebtoken": "^9.0.2",
@@ -18,6 +18,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@rdcp.dev/client": "^1.0.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -41,7 +42,6 @@
         "lint-staged": "^15.2.9",
         "prettier": "^3.1.1",
         "rollup": "^4.9.2",
-        "rollup-plugin-dts": "^6.1.0",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.2",
@@ -1952,6 +1952,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@rdcp.dev/client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rdcp.dev/client/-/client-1.0.0.tgz",
+      "integrity": "sha512-buMkiVNJccdYKD+8sFgUOBpbV7Z0wvkJBDvfnlopkFrYefH7eHNx5PXceT1L1WWuQrfpyLVjBxaV8w6XsanYxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdcp.dev/core": "^1.0.0",
+        "zod": "^3.24.2"
       }
     },
     "node_modules/@rdcp.dev/core": {
@@ -8638,29 +8649,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-dts": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.2.3.tgz",
-      "integrity": "sha512-UgnEsfciXSPpASuOelix7m4DrmyQgiaWBnvI0TM4GxuDh5FkqW8E5hu57bCxXB90VvR1WNfLV80yEDN18UogSA==",
-      "dev": true,
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "magic-string": "^0.30.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Swatinem"
-      },
-      "optionalDependencies": {
-        "@babel/code-frame": "^7.27.1"
-      },
-      "peerDependencies": {
-        "rollup": "^3.29.4 || ^4",
-        "typescript": "^4.5 || ^5.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9906,7 +9894,7 @@
     },
     "packages/rdcp-core": {
       "name": "@rdcp.dev/core",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "build:js": "rollup -c rollup.config.mjs",
     "build": "npm run build:types && npm run build:js",
     "demo:proof": "bash scripts/demo-proof.sh",
+    "demo:client": "node --enable-source-maps scripts/client-demo.mjs",
+    "demo:client:auth": "node --enable-source-maps scripts/client-auth-examples.mjs",
     "lint": "eslint src examples --no-error-on-unmatched-pattern --ext .js,.ts --fix",
     "lint:ci": "eslint src examples --no-error-on-unmatched-pattern --ext .js,.ts --max-warnings=0",
     "pretest": "npm run build:core && npm run build && ( [ \"$CI\" = \"true\" ] || npm install --prefix packages/rdcp-demo-app --no-audit --no-fund )",
@@ -130,7 +132,8 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
     "tsx": "^4.6.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@rdcp.dev/client": "^1.0.0"
   },
   "peerDependencies": {
     "express": "^4.18.0",

--- a/scripts/client-auth-examples.mjs
+++ b/scripts/client-auth-examples.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/*
+ Simple auth mode examples for RDCP client.
+
+ Examples:
+   # API key
+   RDCP_BASE_URL=http://localhost:3000 RDCP_AUTH_METHOD=api-key RDCP_API_KEY=your-key node scripts/client-auth-examples.mjs
+
+   # Bearer token
+   RDCP_BASE_URL=http://localhost:3000 RDCP_AUTH_METHOD=bearer RDCP_BEARER_TOKEN=jwt node scripts/client-auth-examples.mjs
+*/
+
+import { createRDCPClient } from '@rdcp.dev/client'
+import { RDCP_HEADERS } from '@rdcp.dev/core'
+
+function buildHeaders({ method, clientId, tenant, apiKey, bearer }) {
+  const m = (method || 'api-key').toLowerCase()
+  const headers = {
+    [RDCP_HEADERS.AUTH_METHOD]: m,
+    [RDCP_HEADERS.CLIENT_ID]: clientId || 'demo-client',
+  }
+  if (tenant) headers[RDCP_HEADERS.TENANT_ID] = tenant
+  if (m === 'api-key' && apiKey) headers['x-api-key'] = apiKey
+  if (m === 'bearer' && bearer) headers['authorization'] = `Bearer ${bearer}`
+  return headers
+}
+
+async function run(baseUrl, headers) {
+  const rdcp = createRDCPClient({ baseUrl, headers })
+  const s = await rdcp.getStatus()
+  console.log('OK', { timestamp: s.timestamp })
+}
+
+async function main() {
+  const baseUrl = process.env.RDCP_BASE_URL || 'http://localhost:3000'
+  const method = (process.env.RDCP_AUTH_METHOD || 'api-key').toLowerCase()
+  const headers = buildHeaders({
+    method,
+    clientId: process.env.RDCP_CLIENT_ID,
+    tenant: process.env.RDCP_TENANT_ID,
+    apiKey: process.env.RDCP_API_KEY,
+    bearer: process.env.RDCP_BEARER_TOKEN,
+  })
+
+  console.log('Auth method:', method)
+  await run(baseUrl, headers)
+}
+
+main().catch((err) => {
+  console.error('Auth example failed:', err)
+  process.exit(1)
+})

--- a/scripts/client-demo.mjs
+++ b/scripts/client-demo.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/*
+ RDCP Client-first demo script
+
+ Usage:
+   RDCP_BASE_URL=http://localhost:3000 \
+   RDCP_AUTH_METHOD=api-key \
+   RDCP_CLIENT_ID=demo-client \
+   RDCP_API_KEY=your-32+char-key \
+   node scripts/client-demo.mjs
+
+ Env vars:
+   RDCP_BASE_URL       - Base URL of the RDCP server (default: http://localhost:3000)
+   RDCP_CLIENT_ID      - Client identifier (default: demo-client)
+   RDCP_TENANT_ID      - Optional tenant id
+   RDCP_AUTH_METHOD    - api-key | bearer | mtls (default: api-key)
+   RDCP_API_KEY        - API key (when RDCP_AUTH_METHOD=api-key)
+   RDCP_BEARER_TOKEN   - Bearer token (when RDCP_AUTH_METHOD=bearer)
+*/
+
+import { createRDCPClient } from '@rdcp.dev/client'
+import { RDCP_HEADERS } from '@rdcp.dev/core'
+
+function buildHeaders() {
+  const method = (process.env.RDCP_AUTH_METHOD || 'api-key').toLowerCase()
+  const clientId = process.env.RDCP_CLIENT_ID || 'demo-client'
+  const tenant = process.env.RDCP_TENANT_ID
+  const headers = {
+    [RDCP_HEADERS.AUTH_METHOD]: method,
+    [RDCP_HEADERS.CLIENT_ID]: clientId,
+  }
+  if (tenant) headers[RDCP_HEADERS.TENANT_ID] = tenant
+
+  if (method === 'api-key') {
+    const key = process.env.RDCP_API_KEY
+    if (key) headers['x-api-key'] = key
+  } else if (method === 'bearer') {
+    const token = process.env.RDCP_BEARER_TOKEN
+    if (token) headers['authorization'] = `Bearer ${token}`
+  }
+  return headers
+}
+
+async function main() {
+  const baseUrl = process.env.RDCP_BASE_URL || 'http://localhost:3000'
+  const headers = buildHeaders()
+  const rdcp = createRDCPClient({ baseUrl, headers })
+
+  console.log('RDCP baseUrl:', baseUrl)
+  console.log('RDCP headers:', {
+    [RDCP_HEADERS.AUTH_METHOD]: headers[RDCP_HEADERS.AUTH_METHOD],
+    [RDCP_HEADERS.CLIENT_ID]: headers[RDCP_HEADERS.CLIENT_ID],
+    [RDCP_HEADERS.TENANT_ID]: headers[RDCP_HEADERS.TENANT_ID],
+    'authorization?': Boolean(headers['authorization']),
+    'x-api-key?': Boolean(headers['x-api-key']),
+  })
+
+  console.log('\n1) Protocol discovery (.well-known/rdcp via server SDK; discovery via client)')
+  const discovery = await rdcp.getDiscovery()
+  console.log('Discovery categories:', Object.keys(discovery.categories || {}))
+
+  console.log('\n2) Status before changes')
+  const status0 = await rdcp.getStatus()
+  console.log('Status:', { categories: status0.categories, timestamp: status0.timestamp })
+
+  console.log('\n3) Enable a debug category with TTL (2m)')
+  const controlRes = await rdcp.postControl({
+    action: 'enable',
+    categories: ['API_ROUTES'],
+    temporary: '2m',
+  })
+  console.log('Control response:', { success: controlRes.success, timestamp: controlRes.timestamp })
+
+  console.log('\n4) Status after change')
+  const status1 = await rdcp.getStatus()
+  console.log('Status:', { categories: status1.categories, timestamp: status1.timestamp })
+
+  console.log('\n5) Health check')
+  const health = await rdcp.getHealth()
+  console.log('Health:', { status: health.status, timestamp: health.timestamp })
+
+  console.log('\nDone.')
+}
+
+main().catch((err) => {
+  console.error('RDCP client demo failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Phase 1 for #75: add client-first demo scripts and npm run targets.\n\n- scripts/client-demo.mjs: discovery → status → control (TTL 2m) → status → health\n- scripts/client-auth-examples.mjs: minimal Basic/Bearer auth examples\n- root package.json: add demo:client and demo:client:auth\n- devDep: @rdcp.dev/client ^1.0.0 (for scripts)\n\nUsage:\n```bash\n# start demo server\nnpm run dev --prefix packages/rdcp-demo-app\n\n# run client demo (api-key default)\nRDCP_API_KEY=your-32+char-key npm run demo:client\n\n# bearer example\nRDCP_AUTH_METHOD=bearer RDCP_BEARER_TOKEN=your-jwt npm run demo:client:auth\n```\n\nNotes:\n- Scripts read RDCP_* env vars (BASE_URL, CLIENT_ID, TENANT_ID, AUTH_METHOD, API_KEY/BEARER_TOKEN)\n- This is scripts + basic docs; tests/CI will follow in subsequent phases.