### PR TITLE
chore(submodules): add .gitmodules for wiki (.wiki-edit)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".wiki-edit"]
+	path = .wiki-edit
+	url = https://github.com/mojoatomic/rdcp.wiki.git
+	branch = master


### PR DESCRIPTION
Adds .gitmodules entry for the wiki submodule so future clones can init/update it automatically.

[submodule ".wiki-edit"]
- path = .wiki-edit
- url = https://github.com/mojoatomic/rdcp.wiki.git
- branch = master

This formalizes submodule metadata and makes `git submodule update --init --recursive` work out-of-the-box. No code changes.