### PR TITLE
docs: client-first docs + wiki pages; demo benchmark script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".wiki-edit"]
+	path = .wiki-edit
+	url = https://github.com/mojoatomic/rdcp.wiki.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -13,6 +13,45 @@ First-of-its-kind JavaScript/TypeScript SDK implementing the Runtime Debug Contr
 
 ## Install
 
+Quick start (Client SDK)
+
+```ts path=null start=null
+import { createRDCPClient } from '@rdcp.dev/client'
+import { RDCP_HEADERS } from '@rdcp.dev/core'
+
+const rdcp = createRDCPClient({
+  baseUrl: process.env.RDCP_BASE_URL || 'http://localhost:3000',
+  headers: {
+    [RDCP_HEADERS.AUTH_METHOD]: 'api-key',
+    [RDCP_HEADERS.CLIENT_ID]: 'demo-client',
+    'x-api-key': process.env.RDCP_API_KEY!,
+  },
+})
+
+// Discovery
+const discovery = await rdcp.getDiscovery()
+
+// Status
+const status = await rdcp.getStatus()
+
+// Control
+const res = await rdcp.postControl({ action: 'enable', categories: ['API_ROUTES'] })
+
+// Health
+const health = await rdcp.getHealth()
+```
+
+Run the demo locally with the client SDK:
+
+```bash
+npm run dev --prefix packages/rdcp-demo-app # start demo app
+npm run demo:client                         # run client demo flows
+npm run demo:client:auth                    # try Basic/Bearer auth examples
+npm run demo:benchmark                      # compare client vs direct fetch
+```
+
+Install packages
+
 ```bash
 # Core (protocol constants, error codes, schemas)
 npm i @rdcp.dev/core
@@ -69,6 +108,10 @@ Authentication tiers, tenant isolation, and audit features exist because operati
 
 ### The Technical Innovation
 
+Prefer the Client SDK for production usage. For raw HTTP users, see Appendix below.
+
+Appendix: raw HTTP example
+
 ```bash
 # Instead of deploying code changes
 # (risky during incidents)
@@ -76,7 +119,7 @@ Authentication tiers, tenant isolation, and audit features exist because operati
 # Send HTTP requests to running systems
 curl -X POST /rdcp/v1/control \
   -H "Content-Type: application/json" \
-  -d '{"action":"enable","categories":["DATABASE"],"temporary":"5m"}'
+  -d '{"action":"enable","categories":["DATABASE"],"options":{"temporary":true,"duration":"5m"}}'
 ```
 
 Debug output activates immediately, provides operational visibility, then automatically disables after 5 minutes.

--- a/scripts/benchmark-client.mjs
+++ b/scripts/benchmark-client.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/*
+Benchmark: @rdcp.dev/client vs direct fetch
+
+Usage:
+  RDCP_BASE_URL=http://localhost:3000 \
+  RDCP_AUTH_METHOD=api-key \
+  RDCP_CLIENT_ID=bench-client \
+  RDCP_API_KEY=your-32+char-key \
+  node scripts/benchmark-client.mjs
+
+Notes:
+- Measures simple GET /status and POST /control (enable/disable) latency
+- Prints averages over N iterations
+*/
+
+import { performance } from 'node:perf_hooks'
+import { createRDCPClient } from '@rdcp.dev/client'
+import { RDCP_HEADERS } from '@rdcp.dev/core'
+
+const N = parseInt(process.env.RDCP_BENCH_ITERS || '10', 10)
+
+function buildHeaders() {
+  const method = (process.env.RDCP_AUTH_METHOD || 'api-key').toLowerCase()
+  const clientId = process.env.RDCP_CLIENT_ID || 'bench-client'
+  const tenant = process.env.RDCP_TENANT_ID
+  const headers = {
+    [RDCP_HEADERS.AUTH_METHOD]: method,
+    [RDCP_HEADERS.CLIENT_ID]: clientId,
+  }
+  if (tenant) headers[RDCP_HEADERS.TENANT_ID] = tenant
+
+  if (method === 'api-key') {
+    const key = process.env.RDCP_API_KEY
+    if (key) headers['x-api-key'] = key
+  } else if (method === 'bearer') {
+    const token = process.env.RDCP_BEARER_TOKEN
+    if (token) headers['authorization'] = `Bearer ${token}`
+  }
+  return headers
+}
+
+async function bench(fn) {
+  const times = []
+  for (let i = 0; i < N; i++) {
+    const t0 = performance.now()
+    // eslint-disable-next-line no-await-in-loop
+    await fn()
+    const t1 = performance.now()
+    times.push(t1 - t0)
+  }
+  const avg = times.reduce((a, b) => a + b, 0) / times.length
+  const p95 = times.slice().sort((a, b) => a - b)[Math.floor(times.length * 0.95) - 1]
+  return { avg, p95, times }
+}
+
+async function benchClient(baseUrl, headers) {
+  const rdcp = createRDCPClient({ baseUrl, headers })
+  const status = await bench(() => rdcp.getStatus())
+  // Toggle enable/disable to avoid rate-limit side-effects; small pause between
+  const controlEnable = await bench(() => rdcp.postControl({ action: 'enable', categories: ['API_ROUTES'] }))
+  const controlDisable = await bench(() => rdcp.postControl({ action: 'disable', categories: ['API_ROUTES'] }))
+  return { status, controlEnable, controlDisable }
+}
+
+async function benchFetch(baseUrl, headers) {
+  const status = await bench(async () => {
+    const res = await fetch(`${baseUrl}/rdcp/v1/status`, { headers })
+    if (!res.ok) throw new Error(`status failed: ${res.status}`)
+    await res.json()
+  })
+  const controlEnable = await bench(async () => {
+    const res = await fetch(`${baseUrl}/rdcp/v1/control`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ action: 'enable', categories: ['API_ROUTES'] }),
+    })
+    if (!res.ok) throw new Error(`control enable failed: ${res.status}`)
+    await res.json()
+  })
+  const controlDisable = await bench(async () => {
+    const res = await fetch(`${baseUrl}/rdcp/v1/control`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...headers },
+      body: JSON.stringify({ action: 'disable', categories: ['API_ROUTES'] }),
+    })
+    if (!res.ok) throw new Error(`control disable failed: ${res.status}`)
+    await res.json()
+  })
+  return { status, controlEnable, controlDisable }
+}
+
+function print(name, r) {
+  const fmt = (x) => `${x.toFixed(2)}ms`
+  console.log(`\n${name}`)
+  console.log(`  status:         avg=${fmt(r.status.avg)}  p95=${fmt(r.status.p95)}`)
+  console.log(`  control enable: avg=${fmt(r.controlEnable.avg)}  p95=${fmt(r.controlEnable.p95)}`)
+  console.log(`  control disable:avg=${fmt(r.controlDisable.avg)}  p95=${fmt(r.controlDisable.p95)}`)
+}
+
+async function main() {
+  const baseUrl = process.env.RDCP_BASE_URL || 'http://localhost:3000'
+  const headers = buildHeaders()
+  console.log(`Benchmarking with N=${N}, baseUrl=${baseUrl}`)
+
+  const client = await benchClient(baseUrl, headers)
+  const direct = await benchFetch(baseUrl, headers)
+
+  print('@rdcp.dev/client', client)
+  print('direct fetch', direct)
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
Docs + scripts for #75\n\n- docs(README): promote Client SDK quick start; move curl to Appendix\n- docs(wiki): add Client SDK Demo page; link from Home\n- docs(wiki): add short “How to trace RDCP control ops (Client SDK)” section\n- feat(demo): add scripts/benchmark-client.mjs + npm run demo:benchmark\n\nAll tests pass (36 suites, 229 tests).