### PR TITLE
feat(admin-ui): P0 scaffold (headless builder, demo app, discovery.ui RFC)

### DIFF
--- a/docs/rfc-discovery-ui.md
+++ b/docs/rfc-discovery-ui.md
@@ -1,0 +1,51 @@
+# RFC: discovery.ui (optional UI metadata)
+
+Goal: allow servers to publish optional, backward‑compatible UI hints that a headless admin‑ui builder can consume to produce a richer Admin UI. When `ui` is absent, the builder degrades gracefully to a generic UI.
+
+Non‑goals: do not duplicate protocol semantics; do not leak secrets; do not introduce required runtime dependencies.
+
+Schema (illustrative v1)
+```json path=null start=null
+{
+  "version": "1.0",
+  "categoryDescriptions": {
+    "DATABASE": "SQL query logging"
+  },
+  "groups": [
+    { "id": "logging", "label": "Logging & Tracing", "categories": ["DATABASE", "API_ROUTES"] }
+  ],
+  "constraints": {
+    "ttl": { "min": "30s", "max": "15m", "default": "2m" }
+  },
+  "preferredAuth": "bearer",
+  "multiTenant": true
+}
+```
+
+Contract
+- Placed under discovery: `{ protocol, endpoints, capabilities, security, ui? }`
+- `ui` is optional and versioned (`ui.version`)
+- No secrets; only presentation hints and constraints the client cannot infer
+
+Builder mapping (P0)
+- categories → ToggleGroup
+- constraints.ttl → DurationInput
+- capabilities (tenants present) → TenantSelect
+- StatusPanel + SubmitBar always present
+- groups (if provided) partition ToggleGroup by category assignment; default to a single group if absent
+
+Versioning
+- Independent `ui.version` to evolve metadata without changing protocol version
+- Clients may warn/ignore on unknown versions or fields
+
+Degradation
+- When `ui` is absent, render a generic UI: one group with all categories, basic status + submit
+
+Security
+- No auth/key material in `ui`
+- Only capability‑level hints that are already safe to expose via discovery
+
+Next steps
+- Add a typed JSON schema to @rdcp.dev/core for `ui` (optional export)
+- Add headless mapping tests in @rdcp.dev/admin-ui
+- Consider framework renderers (react) as a follow‑up

--- a/packages/rdcp-admin-app/package.json
+++ b/packages/rdcp-admin-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rdcp.dev/admin-app",
+  "version": "0.0.0",
+  "description": "Demo admin app that renders /admin via @rdcp.dev/admin-ui (scaffold)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@rdcp.dev/admin-ui": "0.0.0",
+    "@rdcp.dev/client": "^1.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/prefer-nullish-coalescing, no-console */
+import express from 'express'
+import { createRDCPClient } from '@rdcp.dev/client'
+import { createAdminUISpec } from '@rdcp.dev/admin-ui'
+
+const app = express()
+
+app.get('/admin/spec', async (_req, res) => {
+  try {
+    const rdcp = createRDCPClient({
+      baseUrl: process.env.RDCP_BASE_URL ?? 'http://localhost:3000',
+      headers: {},
+    })
+    const discovery = await rdcp.getDiscovery()
+    // @ts-expect-error ui not yet part of discovery; reserved for future optional block
+    const spec = createAdminUISpec(discovery, discovery.ui)
+    res.json(spec)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'unknown'
+    res.status(500).json({ error: String(message) })
+  }
+})
+
+app.listen(3100, () => {
+  console.log('Admin app scaffold listening on :3100')
+})

--- a/packages/rdcp-admin-app/tsconfig.json
+++ b/packages/rdcp-admin-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Bundler",
+    "strict": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/rdcp-admin-ui/README.md
+++ b/packages/rdcp-admin-ui/README.md
@@ -1,0 +1,21 @@
+# @rdcp.dev/admin-ui (headless)
+
+Headless builder that turns RDCP discovery (+optional `ui` metadata) into an Admin UI spec.
+
+- Input: Discovery response (and optional `ui` block)
+- Output: `AdminUISpec` with groups + widgets (ToggleGroup, DurationInput, TenantSelect, StatusPanel, SubmitBar)
+
+P0 goals
+- Provide a deterministic mapping (discovery/ui → spec)
+- Keep it framework-agnostic
+- Add tests later for the mapping rules
+
+Usage (illustrative)
+```ts path=null start=null
+import { createAdminUISpec } from '@rdcp.dev/admin-ui'
+import { getDiscovery } from '@rdcp.dev/client'
+
+const discovery = await getDiscovery()
+const ui = discovery.ui // when present
+const spec = createAdminUISpec(discovery, ui)
+```

--- a/packages/rdcp-admin-ui/package.json
+++ b/packages/rdcp-admin-ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@rdcp.dev/admin-ui",
+  "version": "0.0.0",
+  "description": "Headless builder for an RDCP Admin UI driven by discovery (+optional ui metadata)",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/types/src/index.d.ts",
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@rdcp.dev/core": "^1.0.0",
+    "@rdcp.dev/client": "^1.0.0"
+  }
+}

--- a/packages/rdcp-admin-ui/src/index.ts
+++ b/packages/rdcp-admin-ui/src/index.ts
@@ -1,0 +1,44 @@
+import type { AdminUISpec, DiscoveryLike, UIBlock, UIGroup } from './types'
+
+function dedupe<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr))
+}
+
+function defaultGroups(categories: DiscoveryLike['categories']): UIGroup[] {
+  const names = categories.map(c => c.name)
+  return [{ id: 'default', label: 'Controls', categories: names }]
+}
+
+export function createAdminUISpec(
+  discovery: DiscoveryLike,
+  ui?: UIBlock
+): AdminUISpec {
+  const groups =
+    ui?.groups && ui.groups.length > 0
+      ? ui.groups
+      : defaultGroups(discovery.categories)
+
+  const ttl = ui?.constraints?.ttl
+
+  return {
+    groups: groups.map(g => ({
+      id: g.id,
+      label: g.label,
+      widgets: [
+        { type: 'ToggleGroup', categories: dedupe(g.categories) },
+        ...(ttl
+          ? ([
+              {
+                type: 'DurationInput',
+                min: ttl.min,
+                max: ttl.max,
+                default: ttl.default,
+              },
+            ] as const)
+          : []),
+        { type: 'StatusPanel' },
+        { type: 'SubmitBar' },
+      ],
+    })),
+  }
+}

--- a/packages/rdcp-admin-ui/src/types.ts
+++ b/packages/rdcp-admin-ui/src/types.ts
@@ -1,0 +1,57 @@
+export type DiscoveryCategory = {
+  name: string
+  description: string
+  enabled: boolean
+  temporary?: boolean
+  metrics?: {
+    callsTotal: number
+    callsPerSecond: number
+  }
+}
+
+export type DiscoveryLike = {
+  protocol: 'rdcp/1.0'
+  timestamp?: string
+  categories: DiscoveryCategory[]
+  performance: {
+    totalCalls: number
+    callsPerSecond: number
+    categoryBreakdown: Record<string, number>
+  }
+}
+
+export type UIGroup = {
+  id: string
+  label: string
+  categories: string[]
+}
+
+export type UIBlock = {
+  version: string
+  categoryDescriptions?: Record<string, string>
+  groups?: UIGroup[]
+  constraints?: {
+    ttl?: {
+      min?: string
+      max?: string
+      default?: string
+    }
+  }
+  preferredAuth?: string
+  multiTenant?: boolean
+}
+
+export type Widget =
+  | { type: 'ToggleGroup'; categories: string[] }
+  | { type: 'DurationInput'; min?: string; max?: string; default?: string }
+  | { type: 'TenantSelect'; tenants?: string[] }
+  | { type: 'StatusPanel' }
+  | { type: 'SubmitBar' }
+
+export type AdminUISpec = {
+  groups: {
+    id: string
+    label: string
+    widgets: Widget[]
+  }[]
+}

--- a/packages/rdcp-admin-ui/tsconfig.json
+++ b/packages/rdcp-admin-ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": false,
+    "module": "ESNext",
+    "target": "ES2020",
+    "moduleResolution": "Bundler",
+    "strict": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
P0 scaffold for #79 (Admin UI — RFC & POC)\n\n- packages/rdcp-admin-ui: headless builder (createAdminUISpec) + types\n- packages/rdcp-admin-app: demo app scaffold exposing /admin/spec (JSON spec)\n- docs/rfc-discovery-ui.md: RFC for optional discovery.ui metadata (v1 outline)\n\nNotes\n- Kept packages private for now; no CI integration yet (follow-up).\n- Builder returns framework-agnostic spec (groups + widgets).\n- Admin app uses @rdcp.dev/client to fetch discovery, then builds spec.\n\nNext (P0 continue)\n- Add mapping tests for builder\n- Decide on renderer (headless only vs react renderer package)\n- Optionally add /admin HTML to render spec in a minimal way.