### PR TITLE
admin-ui P0: builder mapping tests + minimal /admin HTML

### DIFF
--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -21,6 +21,24 @@ app.get('/admin/spec', async (_req, res) => {
   }
 })
 
+app.get('/admin', (_req, res) => {
+  res.type('html').send(`<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>RDCP Admin (Spec)</title></head>
+  <body>
+    <h1>RDCP Admin UI (Spec)</h1>
+    <pre id="out">Loading...</pre>
+    <script>
+      fetch('/admin/spec').then(r=>r.json()).then(j=>{
+        document.getElementById('out').textContent = JSON.stringify(j, null, 2)
+      }).catch(e=>{
+        document.getElementById('out').textContent = 'Error: '+e
+      })
+    </script>
+  </body>
+</html>`)
+})
+
 app.listen(3100, () => {
   console.log('Admin app scaffold listening on :3100')
 })

--- a/packages/rdcp-admin-ui/tests/builder.spec.ts
+++ b/packages/rdcp-admin-ui/tests/builder.spec.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from '@jest/globals'
+import { createAdminUISpec } from '../src/index'
+import type { DiscoveryLike, UIBlock } from '../src/types'
+
+const discovery: DiscoveryLike = {
+  protocol: 'rdcp/1.0',
+  categories: [
+    { name: 'API_ROUTES', description: 'HTTP routes', enabled: false },
+    { name: 'DATABASE', description: 'SQL debug', enabled: false },
+  ],
+  performance: { totalCalls: 0, callsPerSecond: 0, categoryBreakdown: {} },
+}
+
+describe('admin-ui builder', () => {
+  test('defaults to single group with all categories; no TTL widget without constraints', () => {
+    const spec = createAdminUISpec(discovery)
+    expect(spec.groups.length).toBe(1)
+    expect(spec.groups[0].id).toBe('default')
+    const widgets = spec.groups[0].widgets
+    const hasToggle = widgets.some(w => w.type === 'ToggleGroup')
+    const hasDuration = widgets.some(w => w.type === 'DurationInput')
+    const toggle = widgets.find(w => w.type === 'ToggleGroup') as {
+      type: 'ToggleGroup'
+      categories: string[]
+    }
+    expect(hasToggle).toBe(true)
+    expect(hasDuration).toBe(false)
+    expect(toggle.categories.sort()).toEqual(['API_ROUTES', 'DATABASE'].sort())
+  })
+
+  test('adds DurationInput when ttl constraints provided', () => {
+    const ui: UIBlock = {
+      version: '1.0',
+      constraints: { ttl: { min: '30s', max: '15m', default: '2m' } },
+    }
+    const spec = createAdminUISpec(discovery, ui)
+    const widgets = spec.groups[0].widgets
+    const duration = widgets.find(w => w.type === 'DurationInput') as {
+      type: 'DurationInput'
+      min?: string
+      max?: string
+      default?: string
+    }
+    expect(duration).toBeDefined()
+    expect(duration.min).toBe('30s')
+    expect(duration.max).toBe('15m')
+    expect(duration.default).toBe('2m')
+  })
+
+  test('respects provided groups and de-dupes category lists', () => {
+    const ui: UIBlock = {
+      version: '1.0',
+      groups: [
+        {
+          id: 'logging',
+          label: 'Logging',
+          categories: ['API_ROUTES', 'API_ROUTES'],
+        },
+        { id: 'db', label: 'Database', categories: ['DATABASE'] },
+      ],
+    }
+    const spec = createAdminUISpec(discovery, ui)
+    expect(spec.groups.length).toBe(2)
+    const logging = spec.groups.find(g => g.id === 'logging')!
+    const toggle = logging.widgets.find(w => w.type === 'ToggleGroup') as {
+      type: 'ToggleGroup'
+      categories: string[]
+    }
+    expect(toggle.categories).toEqual(['API_ROUTES'])
+  })
+})

--- a/packages/rdcp-admin-ui/tsconfig.json
+++ b/packages/rdcp-admin-ui/tsconfig.json
@@ -11,6 +11,6 @@
     "moduleResolution": "Bundler",
     "strict": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Follow-up for #79 (Admin UI — RFC & POC)\n\n- test(admin-ui): builder mapping tests (default group, TTL constraints, group partitioning)\n- feat(admin-app): adds /admin HTML that fetches /admin/spec and displays JSON (scaffold)\n\nNext:\n- Decide on renderer strategy (headless only vs React renderer)\n- If React, split renderer into @rdcp.dev/admin-ui-react\n- Add more integration tests and minimal styling for /admin (optional).