### PR TITLE
feat(admin-app): SSR /admin using AdminUIRenderer (React); links to JSON/spec

### DIFF
--- a/packages/rdcp-admin-app/package.json
+++ b/packages/rdcp-admin-app/package.json
@@ -10,8 +10,11 @@
   },
   "dependencies": {
     "@rdcp.dev/admin-ui": "0.0.0",
+    "@rdcp.dev/admin-ui-react": "0.0.0",
     "@rdcp.dev/client": "^1.0.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -2,6 +2,9 @@
 import express from 'express'
 import { createRDCPClient } from '@rdcp.dev/client'
 import { createAdminUISpec } from '@rdcp.dev/admin-ui'
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { AdminUIRenderer } from '@rdcp.dev/admin-ui-react'
 
 const app = express()
 
@@ -21,26 +24,41 @@ app.get('/admin/spec', async (_req, res) => {
   }
 })
 
-app.get('/admin', (_req, res) => {
-  res.type('html').send(`<!doctype html>
+app.get('/admin', async (_req, res) => {
+  try {
+    const rdcp = createRDCPClient({
+      baseUrl: process.env.RDCP_BASE_URL ?? 'http://localhost:3000',
+      headers: {},
+    })
+    const discovery = await rdcp.getDiscovery()
+    const spec = createAdminUISpec(discovery)
+    const markup = renderToString(
+      React.createElement(AdminUIRenderer, { spec })
+    )
+    res.type('html').send(`<!doctype html>
 <html>
-  <head><meta charset="utf-8"><title>RDCP Admin (Spec)</title></head>
+  <head>
+    <meta charset="utf-8">
+    <title>RDCP Admin</title>
+    <style>
+      body { font-family: -apple-system, system-ui, Arial; padding: 20px; }
+      section { border: 1px solid #ddd; padding: 12px; margin: 8px 0; border-radius: 6px; }
+      h1 { margin-top: 0; }
+    </style>
+  </head>
   <body>
-    <h1>RDCP Admin UI (Spec)</h1>
+    <h1>RDCP Admin</h1>
     <ul>
       <li><a href="/admin/json" target="_blank">Raw JSON (discovery + status)</a></li>
       <li><a href="/admin/spec" target="_blank">AdminUISpec JSON (headless builder)</a></li>
     </ul>
-    <pre id="out">Loading...</pre>
-    <script>
-      fetch('/admin/spec').then(r=>r.json()).then(j=>{
-        document.getElementById('out').textContent = JSON.stringify(j, null, 2)
-      }).catch(e=>{
-        document.getElementById('out').textContent = 'Error: '+e
-      })
-    </script>
+    <div id="root">${markup}</div>
   </body>
 </html>`)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'unknown'
+    res.status(500).send(`Error: ${String(message)}`)
+  }
 })
 
 app.get('/admin/json', async (_req, res) => {


### PR DESCRIPTION
Part of #79. Renders AdminUISpec server-side under /admin using @rdcp.dev/admin-ui-react. Adds minimal styling and keeps dual JSON endpoints (/admin/spec, /admin/json).