### PR TITLE
feat(admin-ui): actions + polling (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Rather than requiring integration with specific platforms, RDCP defines standard
 
 ---
 
+## Admin UI (Actions + Polling)
+
+The demo Admin UI at `/admin` demonstrates real-time operational control with:
+
+- Action selector: enable/disable/toggle/reset
+- Jittered polling (~1s + 0–300ms), exponential backoff (cap ~10s)
+- Pause during control operations; immediate resume
+- Inline toasts for success/error, non-blocking feedback
+
+Try it locally:
+- Start the demo app (see packages/rdcp-demo-app/README.md)
+- Visit `/admin` and toggle categories, set optional TTL (e.g., `2m`), and click Apply
+- Watch the Status panel timestamp update and toasts confirm actions
+
+A short GIF can be placed in `docs/assets/admin-ui-demo.gif` and embedded here when available.
+
 ## Operational Infrastructure Control (OIC)
 
 RDCP is the first implementation of a new infrastructure category: Operational Infrastructure Control (OIC).

--- a/docs/admin-ui-actions-polling.md
+++ b/docs/admin-ui-actions-polling.md
@@ -1,0 +1,41 @@
+# Admin UI: Actions + Polling (WIP)
+
+Scope
+- Wire Admin UI React renderer to POST /admin/action to enable/disable/toggle/reset categories
+- Add client-side hydration and minimal state management for interactive flows
+- Poll RDCP status with jitter/backoff; surface progress and errors in-UI
+- Keep SSR for first paint; hydrate for interactivity
+
+Implementation plan
+1) Actions wiring
+   - Button/SubmitBar triggers POST /admin/action
+   - Body: { action, categories, options, tenant? }
+   - Use RDCP baseUrl + headers from server SSR; pass via inline script or dataset
+   - Disable controls while request in-flight; show success/failure toast
+
+2) Status polling
+   - Poll getStatus() with 1s base + jitter; exponential backoff on errors
+   - Update StatusPanel with last timestamp and summary
+   - Stop polling while a control request is in-flight to avoid contention
+
+3) Hydration
+   - Export a small client entry that hydrates the SSR markup and attaches handlers
+   - Keep zero-any types; use strict types for UI state and wire props
+
+4) Tenant + TTL
+   - TenantSelect sets tenant context on actions
+   - DurationInput validates against constraints (min/max) and formats duration strings
+
+5) Tests
+   - Admin app e2e: POST /admin/action flows → status reflects change
+   - Unit tests for renderer state transitions
+
+6) Docs
+   - README: prioritize client SDK usage + Admin UI usage notes
+   - Wiki: "Client SDK Demo" page, OTEL tracing how-to
+
+Notes
+- Keep server route /admin/action as the single control endpoint for the UI
+- Future: replace polling with SSE/WebSockets; keep interface compatible
+
+Refs: #79

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -81,36 +81,58 @@ app.get('/admin', async (_req, res) => {
     <div id="root">${markup}</div>
     <script>
       (function(){
+        var paused = false;
+        var errorCount = 0;
+        var statusEl = document.getElementById('rdcp-status');
+        function setLoading(on){ if (statusEl){ statusEl.setAttribute('data-loading', on ? 'true' : 'false'); if(on){ statusEl.innerHTML = '<strong>Status</strong> <span>(loading...)</span>'; } } }
+        function updateStatus(ts){ if (statusEl){ statusEl.innerHTML = '<strong>Status</strong> ' + (ts ? '<span>(' + ts + ')</span>' : '<span>(idle)</span>'); } }
+        function jitter(ms){ return ms + Math.floor(Math.random()*300); }
+        function nextDelay(ok){ if (ok){ errorCount = 0; return jitter(1000); } else { errorCount = Math.min(errorCount+1, 5); return Math.min(jitter(1000*Math.pow(2,errorCount)), 10000); } }
+        function schedule(ms){ setTimeout(poll, ms); }
+        function poll(){
+          if (paused){ schedule(500); return; }
+          setLoading(true);
+          fetch('/admin/json').then(function(res){ return res.json(); }).then(function(data){
+            try { var ts = data && data.status && data.status.timestamp ? String(data.status.timestamp) : ''; updateStatus(ts); } catch(_){ /* noop */ }
+            setLoading(false);
+            schedule(nextDelay(true));
+          }).catch(function(){ setLoading(false); schedule(nextDelay(false)); });
+        }
         var btn = document.getElementById('rdcp-apply');
-        if (!btn) return;
-        btn.addEventListener('click', function(){
-          try {
-            var boxes = Array.prototype.slice.call(document.querySelectorAll('input[type="checkbox"][data-category]'));
-            var cats = boxes.filter(function(el){ return !!el && el.checked; }).map(function(el){ return el.getAttribute('data-category'); });
-            var tenantEl = document.getElementById('rdcp-tenant');
-            var tenant = tenantEl && tenantEl.value ? String(tenantEl.value) : '';
-            var durEl = document.getElementById('rdcp-duration');
-            var duration = durEl && durEl.value ? String(durEl.value) : '';
-            var options = duration ? { temporary: true, duration: duration } : undefined;
-            var body = { action: 'enable', categories: cats };
-            if (tenant) body.tenantId = tenant;
-            if (options) body.options = options;
-            btn.disabled = true;
-            fetch('/admin/action', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify(body)
-            })
-            .then(function(res){ return res.text().then(function(t){ try { return { ok: res.ok, data: JSON.parse(t) }; } catch(_){ return { ok: res.ok, data: t }; } }); })
-            .then(function(result){
-              if (result.ok) alert('Applied successfully'); else alert('Failed: ' + (result && result.data && result.data.error ? result.data.error : 'unknown'));
-            })
-            .catch(function(err){ alert('Error: ' + err); })
-            .finally(function(){ btn.disabled = false; });
-          } catch (e) {
-            alert('Error: ' + e);
-          }
-        });
+        if (btn){
+          btn.addEventListener('click', function(){
+            try {
+              paused = true;
+              var boxes = Array.prototype.slice.call(document.querySelectorAll('input[type="checkbox"][data-category]'));
+              var cats = boxes.filter(function(el){ return !!el && el.checked; }).map(function(el){ return el.getAttribute('data-category'); });
+              var tenantEl = document.getElementById('rdcp-tenant');
+              var tenant = tenantEl && tenantEl.value ? String(tenantEl.value) : '';
+              var durEl = document.getElementById('rdcp-duration');
+              var duration = durEl && durEl.value ? String(durEl.value) : '';
+              var options = duration ? { temporary: true, duration: duration } : undefined;
+              var body = { action: 'enable', categories: cats };
+              if (tenant) body.tenantId = tenant;
+              if (options) body.options = options;
+              btn.disabled = true;
+              fetch('/admin/action', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify(body)
+              })
+              .then(function(res){ return res.text().then(function(t){ try { return { ok: res.ok, data: JSON.parse(t) }; } catch(_){ return { ok: res.ok, data: t }; } }); })
+              .then(function(result){
+                if (result.ok) alert('Applied successfully'); else alert('Failed: ' + (result && result.data && result.data.error ? result.data.error : 'unknown'));
+              })
+              .catch(function(err){ alert('Error: ' + err); })
+              .finally(function(){ btn.disabled = false; paused = false; schedule(0); });
+            } catch (e) {
+              paused = false; schedule(500);
+              alert('Error: ' + e);
+            }
+          });
+        }
+        // start polling
+        schedule(0);
       })();
     </script>
   </body>

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -70,6 +70,10 @@ app.get('/admin', async (_req, res) => {
       body { font-family: -apple-system, system-ui, Arial; padding: 20px; }
       section { border: 1px solid #ddd; padding: 12px; margin: 8px 0; border-radius: 6px; }
       h1 { margin-top: 0; }
+      #rdcp-toast { position: fixed; right: 20px; bottom: 20px; max-width: 360px; background: #222; color: #fff; padding: 10px 12px; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.2); opacity: 0; pointer-events: none; transform: translateY(10px); transition: opacity .2s ease, transform .2s ease; font-size: 14px; }
+      #rdcp-toast.show { opacity: 0.95; transform: translateY(0); }
+      #rdcp-toast.success { background: #137333; }
+      #rdcp-toast.error { background: #a50e0e; }
     </style>
   </head>
   <body>
@@ -79,11 +83,22 @@ app.get('/admin', async (_req, res) => {
       <li><a href="/admin/spec" target="_blank">AdminUISpec JSON (headless builder)</a></li>
     </ul>
     <div id="root">${markup}</div>
+    <div id="rdcp-toast" role="status" aria-live="polite" aria-atomic="true" />
     <script>
       (function(){
         var paused = false;
         var errorCount = 0;
         var statusEl = document.getElementById('rdcp-status');
+        var toastEl = document.getElementById('rdcp-toast');
+        var toastTimer = null;
+        function showToast(msg, type){
+          if (!toastEl) return;
+          toastEl.textContent = String(msg || '');
+          toastEl.classList.remove('success','error');
+          if (type) toastEl.classList.add(String(type));
+          toastEl.classList.add('show');
+          clearTimeout(toastTimer); toastTimer = setTimeout(function(){ toastEl.classList.remove('show'); }, 2500);
+        }
         function setLoading(on){ if (statusEl){ statusEl.setAttribute('data-loading', on ? 'true' : 'false'); if(on){ statusEl.innerHTML = '<strong>Status</strong> <span>(loading...)</span>'; } } }
         function updateStatus(ts){ if (statusEl){ statusEl.innerHTML = '<strong>Status</strong> ' + (ts ? '<span>(' + ts + ')</span>' : '<span>(idle)</span>'); } }
         function jitter(ms){ return ms + Math.floor(Math.random()*300); }
@@ -110,7 +125,9 @@ app.get('/admin', async (_req, res) => {
               var durEl = document.getElementById('rdcp-duration');
               var duration = durEl && durEl.value ? String(durEl.value) : '';
               var options = duration ? { temporary: true, duration: duration } : undefined;
-              var body = { action: 'enable', categories: cats };
+              var actionEl = document.getElementById('rdcp-action');
+              var action = actionEl && actionEl.value ? String(actionEl.value) : 'enable';
+              var body = { action: action, categories: cats };
               if (tenant) body.tenantId = tenant;
               if (options) body.options = options;
               btn.disabled = true;
@@ -121,13 +138,13 @@ app.get('/admin', async (_req, res) => {
               })
               .then(function(res){ return res.text().then(function(t){ try { return { ok: res.ok, data: JSON.parse(t) }; } catch(_){ return { ok: res.ok, data: t }; } }); })
               .then(function(result){
-                if (result.ok) alert('Applied successfully'); else alert('Failed: ' + (result && result.data && result.data.error ? result.data.error : 'unknown'));
+                if (result.ok) showToast('Applied successfully','success'); else showToast('Failed: ' + (result && result.data && result.data.error ? result.data.error : 'unknown'),'error');
               })
-              .catch(function(err){ alert('Error: ' + err); })
+              .catch(function(err){ showToast('Error: ' + err,'error'); })
               .finally(function(){ btn.disabled = false; paused = false; schedule(0); });
             } catch (e) {
               paused = false; schedule(500);
-              alert('Error: ' + e);
+              showToast('Error: ' + e,'error');
             }
           });
         }

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -70,10 +70,11 @@ app.get('/admin', async (_req, res) => {
       body { font-family: -apple-system, system-ui, Arial; padding: 20px; }
       section { border: 1px solid #ddd; padding: 12px; margin: 8px 0; border-radius: 6px; }
       h1 { margin-top: 0; }
-      #rdcp-toast { position: fixed; right: 20px; bottom: 20px; max-width: 360px; background: #222; color: #fff; padding: 10px 12px; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.2); opacity: 0; pointer-events: none; transform: translateY(10px); transition: opacity .2s ease, transform .2s ease; font-size: 14px; }
-      #rdcp-toast.show { opacity: 0.95; transform: translateY(0); }
-      #rdcp-toast.success { background: #137333; }
-      #rdcp-toast.error { background: #a50e0e; }
+#rdcp-toast-container { position: fixed; right: 20px; bottom: 20px; display: flex; flex-direction: column; gap: 8px; align-items: flex-end; z-index: 9999; }
+      .rdcp-toast { max-width: 360px; background: #222; color: #fff; padding: 10px 12px; border-radius: 6px; box-shadow: 0 6px 18px rgba(0,0,0,0.2); opacity: 0; transform: translateY(10px); transition: opacity .2s ease, transform .2s ease; font-size: 14px; cursor: pointer; }
+      .rdcp-toast.show { opacity: 0.95; transform: translateY(0); }
+      .rdcp-toast.success { background: #137333; }
+      .rdcp-toast.error { background: #a50e0e; }
     </style>
   </head>
   <body>
@@ -83,21 +84,22 @@ app.get('/admin', async (_req, res) => {
       <li><a href="/admin/spec" target="_blank">AdminUISpec JSON (headless builder)</a></li>
     </ul>
     <div id="root">${markup}</div>
-    <div id="rdcp-toast" role="status" aria-live="polite" aria-atomic="true" />
+<div id="rdcp-toast-container" role="status" aria-live="polite" aria-atomic="true"></div>
     <script>
       (function(){
         var paused = false;
         var errorCount = 0;
         var statusEl = document.getElementById('rdcp-status');
-        var toastEl = document.getElementById('rdcp-toast');
-        var toastTimer = null;
+        var toastContainer = document.getElementById('rdcp-toast-container');
         function showToast(msg, type){
-          if (!toastEl) return;
-          toastEl.textContent = String(msg || '');
-          toastEl.classList.remove('success','error');
-          if (type) toastEl.classList.add(String(type));
-          toastEl.classList.add('show');
-          clearTimeout(toastTimer); toastTimer = setTimeout(function(){ toastEl.classList.remove('show'); }, 2500);
+          if (!toastContainer) return;
+          var el = document.createElement('div');
+          el.className = 'rdcp-toast' + (type ? ' ' + String(type) : '');
+          el.textContent = String(msg || '');
+          el.addEventListener('click', function(){ el.remove(); });
+          toastContainer.appendChild(el);
+          setTimeout(function(){ el.classList.add('show'); }, 10);
+          setTimeout(function(){ el.classList.remove('show'); setTimeout(function(){ el.remove(); }, 200); }, 2500);
         }
         function setLoading(on){ if (statusEl){ statusEl.setAttribute('data-loading', on ? 'true' : 'false'); if(on){ statusEl.innerHTML = '<strong>Status</strong> <span>(loading...)</span>'; } } }
         function updateStatus(ts){ if (statusEl){ statusEl.innerHTML = '<strong>Status</strong> ' + (ts ? '<span>(' + ts + ')</span>' : '<span>(idle)</span>'); } }

--- a/packages/rdcp-admin-app/src/index.ts
+++ b/packages/rdcp-admin-app/src/index.ts
@@ -79,6 +79,40 @@ app.get('/admin', async (_req, res) => {
       <li><a href="/admin/spec" target="_blank">AdminUISpec JSON (headless builder)</a></li>
     </ul>
     <div id="root">${markup}</div>
+    <script>
+      (function(){
+        var btn = document.getElementById('rdcp-apply');
+        if (!btn) return;
+        btn.addEventListener('click', function(){
+          try {
+            var boxes = Array.prototype.slice.call(document.querySelectorAll('input[type="checkbox"][data-category]'));
+            var cats = boxes.filter(function(el){ return !!el && el.checked; }).map(function(el){ return el.getAttribute('data-category'); });
+            var tenantEl = document.getElementById('rdcp-tenant');
+            var tenant = tenantEl && tenantEl.value ? String(tenantEl.value) : '';
+            var durEl = document.getElementById('rdcp-duration');
+            var duration = durEl && durEl.value ? String(durEl.value) : '';
+            var options = duration ? { temporary: true, duration: duration } : undefined;
+            var body = { action: 'enable', categories: cats };
+            if (tenant) body.tenantId = tenant;
+            if (options) body.options = options;
+            btn.disabled = true;
+            fetch('/admin/action', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(body)
+            })
+            .then(function(res){ return res.text().then(function(t){ try { return { ok: res.ok, data: JSON.parse(t) }; } catch(_){ return { ok: res.ok, data: t }; } }); })
+            .then(function(result){
+              if (result.ok) alert('Applied successfully'); else alert('Failed: ' + (result && result.data && result.data.error ? result.data.error : 'unknown'));
+            })
+            .catch(function(err){ alert('Error: ' + err); })
+            .finally(function(){ btn.disabled = false; });
+          } catch (e) {
+            alert('Error: ' + e);
+          }
+        });
+      })();
+    </script>
   </body>
 </html>`)
   } catch (e) {

--- a/packages/rdcp-admin-ui-react/src/index.tsx
+++ b/packages/rdcp-admin-ui-react/src/index.tsx
@@ -63,8 +63,8 @@ export type StatusPanelProps = { status?: { timestamp?: string } }
 export function StatusPanel(props: StatusPanelProps): JSX.Element {
   const { status } = props
   return (
-    <div>
-      <strong>Status</strong> {status?.timestamp ? <span>({status.timestamp})</span> : null}
+    <div id="rdcp-status" data-loading="false">
+      <strong>Status</strong> {status?.timestamp ? <span>({status.timestamp})</span> : <span>(idle)</span>}
     </div>
   )
 }

--- a/packages/rdcp-admin-ui-react/src/index.tsx
+++ b/packages/rdcp-admin-ui-react/src/index.tsx
@@ -79,6 +79,13 @@ export function SubmitBar(props: SubmitBarProps): JSX.Element {
   }
   return (
     <div>
+      <label htmlFor="rdcp-action" style={{ marginRight: 8 }}>Action</label>
+      <select id="rdcp-action" aria-label="action" defaultValue="enable" style={{ marginRight: 12 }}>
+        <option value="enable">enable</option>
+        <option value="disable">disable</option>
+        <option value="toggle">toggle</option>
+        <option value="reset">reset</option>
+      </select>
       <button id="rdcp-apply" onClick={run} disabled={busy || disabled}>Apply</button>
     </div>
   )

--- a/packages/rdcp-admin-ui-react/src/index.tsx
+++ b/packages/rdcp-admin-ui-react/src/index.tsx
@@ -9,10 +9,18 @@ export function ToggleGroup(props: ToggleGroupProps): JSX.Element {
     onChange(next)
   }
   return (
-    <div>
+    <div data-rdcp="toggle-group">
       {categories.map(cat => (
         <label key={cat} style={{ display: 'inline-block', marginRight: 8 }}>
-          <input type="checkbox" checked={selected.includes(cat)} onChange={() => onToggle(cat)} /> {cat}
+          <input
+            type="checkbox"
+            name={`category-${cat}`}
+            data-category={cat}
+            aria-label={`toggle ${cat}`}
+            checked={selected.includes(cat)}
+            onChange={() => onToggle(cat)}
+          />{' '}
+          {cat}
         </label>
       ))}
     </div>
@@ -26,6 +34,7 @@ export function DurationInput(props: DurationInputProps): JSX.Element {
   return (
     <div>
       <input
+        id="rdcp-duration"
         aria-label="duration"
         placeholder="e.g., 2m, 30s"
         value={value}
@@ -41,7 +50,7 @@ export function TenantSelect(props: TenantSelectProps): JSX.Element | null {
   const { tenants, value, onChange } = props
   if (!tenants || tenants.length === 0) return null
   return (
-    <select aria-label="tenant" value={value ?? ''} onChange={e => onChange(e.target.value || undefined)}>
+    <select id="rdcp-tenant" aria-label="tenant" value={value ?? ''} onChange={e => onChange(e.target.value || undefined)}>
       <option value="">(global)</option>
       {tenants.map(t => (
         <option key={t} value={t}>{t}</option>
@@ -70,7 +79,7 @@ export function SubmitBar(props: SubmitBarProps): JSX.Element {
   }
   return (
     <div>
-      <button onClick={run} disabled={busy || disabled}>Apply</button>
+      <button id="rdcp-apply" onClick={run} disabled={busy || disabled}>Apply</button>
     </div>
   )
 }

--- a/tests/admin-app.actions.e2e.test.ts
+++ b/tests/admin-app.actions.e2e.test.ts
@@ -1,0 +1,84 @@
+import http from 'http'
+import request from 'supertest'
+import type { Application } from 'express'
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals'
+
+// Import admin app (ESM export)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  app,
+}: { app: Application } = require('./../packages/rdcp-admin-app/src/index.ts')
+// Import demo app (CJS)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  app: demoApp,
+}: { app: Application } = require('../packages/rdcp-demo-app/src/app.js')
+
+/**
+ * E2E: Admin app actions → status feedback loop
+ */
+describe('Admin app actions → status feedback loop', () => {
+  let adminServer: http.Server
+  let demoServer: http.Server
+  let adminBase = ''
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test'
+    // Start demo app
+    demoServer = await new Promise<http.Server>(resolve => {
+      const s = (demoApp as Application).listen(0, () => resolve(s))
+    })
+    const daddr = demoServer.address()
+    const dport = typeof daddr === 'object' && daddr ? daddr.port : 0
+    const demoBase = `http://127.0.0.1:${dport}`
+    process.env.RDCP_BASE_URL = demoBase
+
+    // Start admin app
+    adminServer = await new Promise<http.Server>(resolve => {
+      const s = (app as Application).listen(0, () => resolve(s))
+    })
+    const aaddr = adminServer.address()
+    const aport = typeof aaddr === 'object' && aaddr ? aaddr.port : 0
+    adminBase = `http://127.0.0.1:${aport}`
+  })
+
+  afterAll(async () => {
+    if (adminServer) await new Promise(r => adminServer.close(() => r(null)))
+    if (demoServer) await new Promise(r => demoServer.close(() => r(null)))
+  })
+
+  function safeTimestamp(body: unknown): string {
+    if (typeof body !== 'object' || body === null) return ''
+    const obj = body as Record<string, unknown>
+    const status = obj.status
+    if (typeof status !== 'object' || status === null) return ''
+    const st = status as Record<string, unknown>
+    const ts = st.timestamp
+    return typeof ts === 'string' ? ts : ''
+  }
+
+  test('POST /admin/action followed by /admin/json shows updated status timestamp', async () => {
+    const before = await request(adminBase).get('/admin/json')
+    expect(before.status).toBe(200)
+    const ts0 = safeTimestamp(before.body as unknown)
+
+    const res = await request(adminBase)
+      .post('/admin/action')
+      .set('content-type', 'application/json')
+      .send({ action: 'enable', categories: ['API_ROUTES'] })
+    expect(typeof res.status).toBe('number')
+    expect(res.status).toBe(200)
+
+    // Small delay to allow status to update
+    await new Promise(r => setTimeout(r, 50))
+
+    const after = await request(adminBase).get('/admin/json')
+    expect(after.status).toBe(200)
+    const ts1 = safeTimestamp(after.body as unknown)
+
+    // Timestamp should be present and (usually) change
+    expect(typeof ts1).toBe('string')
+    // If ts0 existed, ts1 should be different or at least non-empty
+    if (ts0) expect(ts1).not.toBe(ts0)
+  })
+})

--- a/tests/admin-app.disable.actions.e2e.test.ts
+++ b/tests/admin-app.disable.actions.e2e.test.ts
@@ -1,0 +1,77 @@
+import http from 'http'
+import request from 'supertest'
+import type { Application } from 'express'
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals'
+
+// Import admin app (ESM export)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  app,
+}: { app: Application } = require('./../packages/rdcp-admin-app/src/index.ts')
+// Import demo app (CJS)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  app: demoApp,
+}: { app: Application } = require('../packages/rdcp-demo-app/src/app.js')
+
+function ts(body: unknown): string {
+  if (typeof body !== 'object' || body === null) return ''
+  const o = body as Record<string, unknown>
+  const s = o.status as Record<string, unknown> | undefined
+  const v = s && typeof s.timestamp === 'string' ? s.timestamp : ''
+  return typeof v === 'string' ? v : ''
+}
+
+describe('Admin app disable action updates status', () => {
+  let adminServer: http.Server
+  let demoServer: http.Server
+  let base = ''
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test'
+    demoServer = await new Promise<http.Server>(resolve => {
+      const s = (demoApp as Application).listen(0, () => resolve(s))
+    })
+    const daddr = demoServer.address()
+    const dport = typeof daddr === 'object' && daddr ? daddr.port : 0
+    process.env.RDCP_BASE_URL = `http://127.0.0.1:${dport}`
+
+    adminServer = await new Promise<http.Server>(resolve => {
+      const s = (app as Application).listen(0, () => resolve(s))
+    })
+    const a = adminServer.address()
+    const aport = typeof a === 'object' && a ? a.port : 0
+    base = `http://127.0.0.1:${aport}`
+  })
+  afterAll(async () => {
+    if (adminServer) await new Promise(r => adminServer.close(() => r(null)))
+    if (demoServer) await new Promise(r => demoServer.close(() => r(null)))
+  })
+
+  test('enable then disable triggers status timestamp changes', async () => {
+    const r0 = await request(base).get('/admin/json')
+    expect(r0.status).toBe(200)
+    const t0 = ts(r0.body)
+
+    const en = await request(base)
+      .post('/admin/action')
+      .set('content-type', 'application/json')
+      .send({ action: 'enable', categories: ['API_ROUTES'] })
+    expect(en.status).toBe(200)
+    await new Promise(r => setTimeout(r, 50))
+    const r1 = await request(base).get('/admin/json')
+    expect(r1.status).toBe(200)
+    const t1 = ts(r1.body)
+    if (t0) expect(t1).not.toBe(t0)
+
+    const dis = await request(base)
+      .post('/admin/action')
+      .set('content-type', 'application/json')
+      .send({ action: 'disable', categories: ['API_ROUTES'] })
+    expect(dis.status).toBe(200)
+    await new Promise(r => setTimeout(r, 50))
+    const r2 = await request(base).get('/admin/json')
+    expect(r2.status).toBe(200)
+    const t2 = ts(r2.body)
+    if (t1) expect(t2).not.toBe(t1)
+  })
+})


### PR DESCRIPTION
Implements plan for Admin UI actions + polling.

Scope:
- Wire Admin UI React renderer to POST /admin/action (enable/disable/toggle/reset)
- Add hydration + minimal state for interactivity
- Poll RDCP status with jitter/backoff; surface progress/errors
- Keep SSR for first paint; hydrate for interactivity

Docs:
- Added docs/admin-ui-actions-polling.md (plan)

Refs: #79