### PR TITLE
release: v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rdcp.dev/server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rdcp.dev/server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdcp.dev/server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "JavaScript/TypeScript SDK for Runtime Debug Control Protocol v1.0 endpoints",
   "keywords": [
     "rdcp",


### PR DESCRIPTION
Bump root package to 2.2.0 to match tag. No code changes.