### PR TITLE
chore(release): publish Apache 2.0 patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdcp.dev/server",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "JavaScript/TypeScript SDK for Runtime Debug Control Protocol v1.0 endpoints",
   "keywords": [
     "rdcp",

--- a/packages/otel-plugin/package.json
+++ b/packages/otel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdcp.dev/otel-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry integration plugin for RDCP SDK - Enterprise-grade trace correlation",
   "keywords": [
     "rdcp",
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@rdcp.dev/server": "file:../../../.."
+    "@rdcp.dev/server": "^2.2.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/rdcp-client/package.json
+++ b/packages/rdcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdcp.dev/client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/rdcp-core/package.json
+++ b/packages/rdcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdcp.dev/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Published patch versions reflecting Apache 2.0 license:
- @rdcp.dev/server: 2.2.1
- @rdcp.dev/core: 1.0.1
- @rdcp.dev/client: 1.0.1
- @rdcp.dev/otel-plugin: 1.0.1 (peer fix: @rdcp.dev/server ^2.2.0)

This PR bumps versions and updates otel-plugin peer dependency in repo. No functional code changes.