### PR TITLE
chore: normalize repository.url via npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mojoatomic/rdcp"
+    "url": "git+https://github.com/mojoatomic/rdcp.git"
   },
   "bugs": {
     "url": "https://github.com/rdcp/sdk/issues"

--- a/packages/otel-plugin/package.json
+++ b/packages/otel-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mojoatomic/rdcp",
+    "url": "git+https://github.com/mojoatomic/rdcp.git",
     "directory": "packages/otel-plugin"
   },
   "bugs": {


### PR DESCRIPTION
This normalizes repository.url fields to npm-preferred git+https://... form.

- Root package.json
- packages/otel-plugin/package.json

No functional changes.