### PR TITLE
chore(ci): fix Node 22 rollup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-test-publish:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+      ROLLUP_DISABLE_NATIVE: '1'
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -24,6 +27,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Ensure Rollup native binary is present (linux-x64)
+        run: npm i --no-save @rollup/rollup-linux-x64-gnu || true
 
       - name: Install OpenTelemetry plugin dependencies
         run: npm install --prefix packages/otel-plugin --no-audit --no-fund

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mojoatomic/rdcp"
+    "url": "git+https://github.com/mojoatomic/rdcp.git"
   },
   "bugs": {
     "url": "https://github.com/rdcp/sdk/issues"

--- a/packages/otel-plugin/package.json
+++ b/packages/otel-plugin/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mojoatomic/rdcp",
+    "url": "git+https://github.com/mojoatomic/rdcp.git",
     "directory": "packages/otel-plugin"
   },
   "bugs": {


### PR DESCRIPTION
Fix Node 22 failure in release workflow by:
- Setting ROLLUP_DISABLE_NATIVE=1 (force JS fallback)
- Preinstalling @rollup/rollup-linux-x64-gnu as a safety net (same workaround as CI)

Matches behavior in CI workflow; no functional code changes.